### PR TITLE
List open apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clipx-scaffold",
   "private": true,
-  "version": "0.1.18",
+  "version": "0.1.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -493,6 +493,7 @@ dependencies = [
 name = "clipx-scaffold"
 version = "0.1.18"
 dependencies = [
+ "core-foundation",
  "log",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "clipx-scaffold"
-version = "0.1.18"
+version = "0.1.20"
 dependencies = [
  "log",
  "rusqlite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -493,7 +493,6 @@ dependencies = [
 name = "clipx-scaffold"
 version = "0.1.18"
 dependencies = [
- "core-foundation",
  "log",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,5 +26,8 @@ thiserror = "1"
 log = "0.4"
 simplelog = { version = "0.12", features = ["paris"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10"
+
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,8 +26,5 @@ thiserror = "1"
 log = "0.4"
 simplelog = { version = "0.12", features = ["paris"] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.10"
-
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clipx-scaffold"
-version = "0.1.18"
+version = "0.1.20"
 description = "Desktop clipboard manager with history and pinned items"
 authors = ["adrianojlt"]
 license = "MIT"

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -108,7 +108,9 @@ mod platform {
     pub fn focus_app(id: &str) -> Result<(), AppError> {
         let (app, title) = id.split_once(SEP).unwrap_or((id, ""));
 
-        if app.contains('"') || title.contains('"') {
+        if app.chars().any(|c| matches!(c, '"' | '\\' | '\0' | '\r' | '\n' | '\t'))
+            || title.chars().any(|c| matches!(c, '"' | '\\' | '\0' | '\r' | '\n' | '\t'))
+        {
             return Err(AppError::Validation("invalid app id".into()));
         }
 

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -22,94 +22,80 @@ pub async fn focus_app(id: String) -> Result<(), AppError> {
 mod platform {
     use super::OpenApp;
     use crate::error::AppError;
-    use core_foundation::array::{CFArray, CFArrayRef};
-    use core_foundation::base::{TCFType, ToVoid};
-    use core_foundation::dictionary::CFDictionary;
-    use core_foundation::number::CFNumber;
-    use core_foundation::string::CFString;
     use std::collections::HashSet;
     use std::process::Command;
 
     // Separator packed into `id` to carry both process name and window title.
     const SEP: char = '\u{1f}';
 
-    // CGWindowListOption flags.
-    const ON_SCREEN_ONLY: u32 = 1 << 0;
-    const EXCLUDE_DESKTOP_ELEMENTS: u32 = 1 << 4;
-    const NULL_WINDOW_ID: u32 = 0;
-
-    #[link(name = "CoreGraphics", kind = "framework")]
-    extern "C" {
-        fn CGWindowListCopyWindowInfo(option: u32, relative_to_window: u32) -> CFArrayRef;
-    }
-
-    fn dict_string(dict: &CFDictionary, key: &CFString) -> Option<String> {
-        let raw = dict.find(key.to_void())?;
-        let value = unsafe { core_foundation::base::CFType::wrap_under_get_rule(*raw) };
-        value.downcast::<CFString>().map(|s| s.to_string())
-    }
-
-    fn dict_i64(dict: &CFDictionary, key: &CFString) -> Option<i64> {
-        let raw = dict.find(key.to_void())?;
-        let value = unsafe { core_foundation::base::CFType::wrap_under_get_rule(*raw) };
-        value.downcast::<CFNumber>().and_then(|n| n.to_i64())
-    }
-
-    // One entry per on-screen window via CoreGraphics (in-process, fast).
-    // Window titles (kCGWindowName) need Screen Recording permission; without
-    // it the title is empty and entries collapse to one per app.
+    // List windows via each app's Window menu (Accessibility). An app's open
+    // windows are the last N items of its Window menu (N = AX window count),
+    // which are exactly the strings focus_app clicks - so list and focus always
+    // agree, including for Chromium/Electron apps. Needs Accessibility only.
+    // Output lines: "<process name>\t<window title>" (title empty if none).
     pub fn list_open_apps() -> Result<Vec<OpenApp>, AppError> {
+        let script = "set output to \"\"\n\
+            tell application \"System Events\"\n\
+            repeat with p in (every process whose background only is false)\n\
+            set pname to name of p\n\
+            set emitted to false\n\
+            try\n\
+            set allItems to name of every menu item of menu 1 of (menu bar item \"Window\" of menu bar 1 of p)\n\
+            set total to count of allItems\n\
+            set sepIndex to 0\n\
+            repeat with i from 1 to total\n\
+            if item i of allItems is missing value then set sepIndex to i\n\
+            end repeat\n\
+            if sepIndex > 0 and sepIndex < total then\n\
+            repeat with i from (sepIndex + 1) to total\n\
+            set t to item i of allItems\n\
+            if t is not missing value then\n\
+            set output to output & pname & tab & (t as text) & linefeed\n\
+            set emitted to true\n\
+            end if\n\
+            end repeat\n\
+            end if\n\
+            end try\n\
+            if not emitted then\n\
+            set output to output & pname & tab & \"\" & linefeed\n\
+            end if\n\
+            end repeat\n\
+            end tell\n\
+            return output";
 
-        let key_owner = CFString::from_static_string("kCGWindowOwnerName");
-        let key_name = CFString::from_static_string("kCGWindowName");
-        let key_layer = CFString::from_static_string("kCGWindowLayer");
+        let out = Command::new("osascript")
+            .arg("-e")
+            .arg(script)
+            .output()
+            .map_err(|e| AppError::State(format!("osascript failed: {e}")))?;
 
-        let array_ref = unsafe {
-            CGWindowListCopyWindowInfo(
-                ON_SCREEN_ONLY | EXCLUDE_DESKTOP_ELEMENTS,
-                NULL_WINDOW_ID,
-            )
-        };
-
-        if array_ref.is_null() {
-            return Err(AppError::State(
-                "CGWindowListCopyWindowInfo returned null".into(),
-            ));
+        if !out.status.success() {
+            return Err(AppError::State(format!(
+                "osascript error: {}",
+                String::from_utf8_lossy(&out.stderr)
+            )));
         }
 
-        let windows: CFArray<CFDictionary> = unsafe { CFArray::wrap_under_create_rule(array_ref) };
-
+        let stdout = String::from_utf8_lossy(&out.stdout);
         let mut seen: HashSet<String> = HashSet::new();
         let mut apps: Vec<OpenApp> = Vec::new();
 
-        for dict in windows.iter() {
-
-            // Layer 0 = normal app windows; skip menubar/dock/overlays.
-            if dict_i64(&dict, &key_layer).unwrap_or(-1) != 0 {
+        for line in stdout.lines() {
+            let (app, title) = line.split_once('\t').unwrap_or((line, ""));
+            let app = app.trim();
+            let title = title.trim();
+            if app.is_empty() {
                 continue;
             }
-
-            let app = match dict_string(&dict, &key_owner) {
-                Some(a) if !a.trim().is_empty() => a.trim().to_string(),
-                _ => continue,
-            };
-
-            let title = dict_string(&dict, &key_name)
-                .map(|t| t.trim().to_string())
-                .unwrap_or_default();
-
             let id = format!("{app}{SEP}{title}");
-
             if !seen.insert(id.clone()) {
                 continue;
             }
-
             let name = if title.is_empty() {
-                app
+                app.to_string()
             } else {
                 format!("{app} - {title}")
             };
-
             apps.push(OpenApp { name, id });
         }
 
@@ -126,17 +112,33 @@ mod platform {
             return Err(AppError::Validation("invalid app id".into()));
         }
 
-        let raise = if title.is_empty() {
-            String::new()
+        // Raise the window via the app's own Window menu item. AXRaise/AXMain
+        // are ignored by Chromium/Electron apps (Chrome, VS Code) for real
+        // focus, but clicking the Window-menu entry is honored everywhere.
+        // Exact title match first, then substring (Chrome decorates titles).
+        // Select the target window via the Window menu BEFORE activating the
+        // app, so the app comes forward already showing the right window (no
+        // flash of the previously-active window).
+        let inner = if title.is_empty() {
+            "set frontmost to true".to_string()
         } else {
             format!(
-                "\nperform action \"AXRaise\" of (first window of process \"{app}\" whose name is \"{title}\")"
+                "try\n\
+                click (first menu item of menu 1 of menu bar item \"Window\" of menu bar 1 whose name is \"{title}\")\n\
+                on error\n\
+                try\n\
+                click (first menu item of menu 1 of menu bar item \"Window\" of menu bar 1 whose name contains \"{title}\")\n\
+                end try\n\
+                end try\n\
+                set frontmost to true"
             )
         };
 
         let script = format!(
             "tell application \"System Events\"\n\
-            set frontmost of process \"{app}\" to true{raise}\n\
+            tell process \"{app}\"\n\
+            {inner}\n\
+            end tell\n\
             end tell"
         );
 

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -1,0 +1,246 @@
+use crate::error::AppError;
+
+#[derive(serde::Serialize, Clone)]
+pub struct OpenApp {
+    pub(crate) name: String,
+    pub(crate) id: String,
+}
+
+// async so Tauri runs these off the main thread; the platform helpers spawn a
+// blocking subprocess and must not freeze the UI event loop.
+#[tauri::command]
+pub async fn list_open_apps() -> Result<Vec<OpenApp>, AppError> {
+    platform::list_open_apps()
+}
+
+#[tauri::command]
+pub async fn focus_app(id: String) -> Result<(), AppError> {
+    platform::focus_app(&id)
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::OpenApp;
+    use crate::error::AppError;
+    use core_foundation::array::{CFArray, CFArrayRef};
+    use core_foundation::base::{TCFType, ToVoid};
+    use core_foundation::dictionary::CFDictionary;
+    use core_foundation::number::CFNumber;
+    use core_foundation::string::CFString;
+    use std::collections::HashSet;
+    use std::process::Command;
+
+    // Separator packed into `id` to carry both process name and window title.
+    const SEP: char = '\u{1f}';
+
+    // CGWindowListOption flags.
+    const ON_SCREEN_ONLY: u32 = 1 << 0;
+    const EXCLUDE_DESKTOP_ELEMENTS: u32 = 1 << 4;
+    const NULL_WINDOW_ID: u32 = 0;
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CGWindowListCopyWindowInfo(option: u32, relative_to_window: u32) -> CFArrayRef;
+    }
+
+    fn dict_string(dict: &CFDictionary, key: &CFString) -> Option<String> {
+        let raw = dict.find(key.to_void())?;
+        let value = unsafe { core_foundation::base::CFType::wrap_under_get_rule(*raw) };
+        value.downcast::<CFString>().map(|s| s.to_string())
+    }
+
+    fn dict_i64(dict: &CFDictionary, key: &CFString) -> Option<i64> {
+        let raw = dict.find(key.to_void())?;
+        let value = unsafe { core_foundation::base::CFType::wrap_under_get_rule(*raw) };
+        value.downcast::<CFNumber>().and_then(|n| n.to_i64())
+    }
+
+    // One entry per on-screen window via CoreGraphics (in-process, fast).
+    // Window titles (kCGWindowName) need Screen Recording permission; without
+    // it the title is empty and entries collapse to one per app.
+    pub fn list_open_apps() -> Result<Vec<OpenApp>, AppError> {
+
+        let key_owner = CFString::from_static_string("kCGWindowOwnerName");
+        let key_name = CFString::from_static_string("kCGWindowName");
+        let key_layer = CFString::from_static_string("kCGWindowLayer");
+
+        let array_ref = unsafe {
+            CGWindowListCopyWindowInfo(
+                ON_SCREEN_ONLY | EXCLUDE_DESKTOP_ELEMENTS,
+                NULL_WINDOW_ID,
+            )
+        };
+
+        if array_ref.is_null() {
+            return Err(AppError::State(
+                "CGWindowListCopyWindowInfo returned null".into(),
+            ));
+        }
+
+        let windows: CFArray<CFDictionary> = unsafe { CFArray::wrap_under_create_rule(array_ref) };
+
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut apps: Vec<OpenApp> = Vec::new();
+
+        for dict in windows.iter() {
+
+            // Layer 0 = normal app windows; skip menubar/dock/overlays.
+            if dict_i64(&dict, &key_layer).unwrap_or(-1) != 0 {
+                continue;
+            }
+
+            let app = match dict_string(&dict, &key_owner) {
+                Some(a) if !a.trim().is_empty() => a.trim().to_string(),
+                _ => continue,
+            };
+
+            let title = dict_string(&dict, &key_name)
+                .map(|t| t.trim().to_string())
+                .unwrap_or_default();
+
+            let id = format!("{app}{SEP}{title}");
+
+            if !seen.insert(id.clone()) {
+                continue;
+            }
+
+            let name = if title.is_empty() {
+                app
+            } else {
+                format!("{app} - {title}")
+            };
+
+            apps.push(OpenApp { name, id });
+        }
+
+        apps.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        Ok(apps)
+    }
+
+    // id == "<process name>\u{1f}<window title>". Bring the process to the
+    // front, then raise the specific window if a title is present.
+    pub fn focus_app(id: &str) -> Result<(), AppError> {
+        let (app, title) = id.split_once(SEP).unwrap_or((id, ""));
+
+        if app.contains('"') || title.contains('"') {
+            return Err(AppError::Validation("invalid app id".into()));
+        }
+
+        let raise = if title.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "\nperform action \"AXRaise\" of (first window of process \"{app}\" whose name is \"{title}\")"
+            )
+        };
+
+        let script = format!(
+            "tell application \"System Events\"\n\
+            set frontmost of process \"{app}\" to true{raise}\n\
+            end tell"
+        );
+
+        let output = Command::new("osascript")
+            .arg("-e")
+            .arg(&script)
+            .output()
+            .map_err(|e| AppError::State(format!("osascript failed: {e}")))?;
+
+        if !output.status.success() {
+            return Err(AppError::State(format!(
+                "failed to focus app: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use super::OpenApp;
+    use crate::error::AppError;
+    use std::os::windows::process::CommandExt;
+    use std::process::Command;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    // List processes that own a visible main window. id = PID, name = window title.
+    pub fn list_open_apps() -> Result<Vec<OpenApp>, AppError> {
+        let script = "Get-Process | Where-Object { $_.MainWindowTitle -ne '' } | \
+            ForEach-Object { \"$($_.Id)`t$($_.MainWindowTitle)\" }";
+
+        let output = Command::new("powershell")
+            .args(["-NoProfile", "-NonInteractive", "-Command", script])
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+            .map_err(|e| AppError::State(format!("powershell failed: {e}")))?;
+
+        if !output.status.success() {
+            return Err(AppError::State(format!(
+                "powershell error: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut apps: Vec<OpenApp> = stdout
+            .lines()
+            .filter_map(|l| {
+                let (pid, title) = l.split_once('\t')?;
+                let title = title.trim();
+                if title.is_empty() {
+                    return None;
+                }
+                Some(OpenApp {
+                    name: title.to_string(),
+                    id: pid.trim().to_string(),
+                })
+            })
+            .collect();
+
+        apps.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        Ok(apps)
+    }
+
+    // id == PID on Windows. AppActivate accepts a PID and raises the window.
+    pub fn focus_app(id: &str) -> Result<(), AppError> {
+        let pid: u32 = id
+            .parse()
+            .map_err(|_| AppError::Validation(format!("invalid app id: {id}")))?;
+
+        let script = format!(
+            "(New-Object -ComObject WScript.Shell).AppActivate({pid})"
+        );
+
+        let output = Command::new("powershell")
+            .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+            .map_err(|e| AppError::State(format!("powershell failed: {e}")))?;
+
+        if !output.status.success() {
+            return Err(AppError::State(format!(
+                "failed to focus app: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+mod platform {
+    use super::OpenApp;
+    use crate::error::AppError;
+
+    pub fn list_open_apps() -> Result<Vec<OpenApp>, AppError> {
+        Err(AppError::State("listing apps not supported on this platform".into()))
+    }
+
+    pub fn focus_app(_id: &str) -> Result<(), AppError> {
+        Err(AppError::State("focusing apps not supported on this platform".into()))
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod apps;
 pub mod clipboard;
 pub mod logging;
 pub mod pinned;

--- a/src-tauri/src/commands/sessions.rs
+++ b/src-tauri/src/commands/sessions.rs
@@ -93,7 +93,10 @@ pub(crate) fn delete_session_impl(conn: &mut rusqlite::Connection, id: i64) -> R
             [id],
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
-        .map_err(|_| AppError::NotFound(id))?;
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => AppError::NotFound(id),
+            other => AppError::Db(other),
+        })?;
 
     if is_global != 0 {
         return Err(AppError::Validation("Cannot delete the Global session".into()));

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -28,6 +28,7 @@ fn apply_field(s: &mut Settings, key: &str, value: &str) -> Result<(), AppError>
                 .parse::<f64>()
                 .map_err(|_| AppError::Validation(format!("Invalid window_height: {value}")))?;
         }
+        "tab_shortcut_apps" => s.tab_shortcut_apps = value.to_string(),
         "tab_shortcut_pinned" => s.tab_shortcut_pinned = value.to_string(),
         "tab_shortcut_history" => s.tab_shortcut_history = value.to_string(),
         "tab_shortcut_sessions" => s.tab_shortcut_sessions = value.to_string(),

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -28,7 +28,6 @@ fn apply_field(s: &mut Settings, key: &str, value: &str) -> Result<(), AppError>
                 .parse::<f64>()
                 .map_err(|_| AppError::Validation(format!("Invalid window_height: {value}")))?;
         }
-        "tab_shortcut_apps" => s.tab_shortcut_apps = value.to_string(),
         "tab_shortcut_pinned" => s.tab_shortcut_pinned = value.to_string(),
         "tab_shortcut_history" => s.tab_shortcut_history = value.to_string(),
         "tab_shortcut_sessions" => s.tab_shortcut_sessions = value.to_string(),
@@ -142,6 +141,32 @@ mod tests {
     }
 }
 
+fn swap_global_shortcut(app: &AppHandle, old: &str, new: &str) -> Result<(), AppError> {
+
+    let normalized_new = normalize_shortcut(new);
+    let normalized_old = normalize_shortcut(old);
+
+    if normalized_new == normalized_old {
+        return Ok(());
+    }
+
+    let new_shortcut = normalized_new
+        .parse::<Shortcut>()
+        .map_err(|e| AppError::Shortcut(e.to_string()))?;
+
+    app.global_shortcut()
+        .on_shortcut(new_shortcut, shortcut_handler)
+        .map_err(|e| AppError::Shortcut(e.to_string()))?;
+
+    if let Ok(old_shortcut) = normalized_old.parse::<Shortcut>() {
+        if let Err(e) = app.global_shortcut().unregister(old_shortcut) {
+            log::warn!("swap_global_shortcut: failed to unregister '{}': {e}", normalized_old);
+        }
+    }
+
+    Ok(())
+}
+
 #[tauri::command]
 pub fn update_shortcut(
     shortcut: String,
@@ -156,27 +181,32 @@ pub fn update_shortcut(
             .lock()
             .map_err(|e| AppError::State(format!("settings mutex poisoned: {e}")))?;
 
-        let normalized_new = normalize_shortcut(&shortcut);
-        let normalized_old = normalize_shortcut(&s.hotkey);
-
-        if normalized_new != normalized_old {
-
-            let new_shortcut = normalized_new
-                .parse::<Shortcut>()
-                .map_err(|e| AppError::Shortcut(e.to_string()))?;
-
-            app.global_shortcut()
-                .on_shortcut(new_shortcut, shortcut_handler)
-                .map_err(|e| AppError::Shortcut(e.to_string()))?;
-
-            if let Ok(old) = normalized_old.parse::<Shortcut>() {
-                if let Err(e) = app.global_shortcut().unregister(old) {
-                    log::warn!("update_shortcut: failed to unregister '{}': {e}", normalized_old);
-                }
-            }
-        }
+        swap_global_shortcut(&app, &s.hotkey, &shortcut)?;
 
         s.hotkey = shortcut;
+        s.clone()
+    };
+
+    save_settings(&app, &settings)
+}
+
+#[tauri::command]
+pub fn update_open_apps_shortcut(
+    shortcut: String,
+    state: State<AppState>,
+    app: tauri::AppHandle,
+) -> Result<(), AppError> {
+
+    let settings = {
+
+        let mut s = state
+            .settings
+            .lock()
+            .map_err(|e| AppError::State(format!("settings mutex poisoned: {e}")))?;
+
+        swap_global_shortcut(&app, &s.open_apps_hotkey, &shortcut)?;
+
+        s.open_apps_hotkey = shortcut;
         s.clone()
     };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,6 +72,7 @@ pub fn run() {
             commands::settings::get_setting,
             commands::settings::set_setting,
             commands::settings::update_shortcut,
+            commands::settings::update_open_apps_shortcut,
             commands::settings::apply_window_size,
             commands::clipboard::get_history,
             commands::pinned::get_pinned,
@@ -204,18 +205,8 @@ fn init_app_state(app: &mut tauri::App) -> Result<(), AppError> {
     Ok(())
 }
 
-fn register_initial_shortcut(app: &AppHandle) -> Result<(), AppError> {
-
-    let state = app.state::<AppState>();
-
-    let hotkey_str = state
-        .settings
-        .lock()
-        .map_err(|_| AppError::State("settings poisoned".into()))?
-        .hotkey
-        .clone();
-
-    let normalized = crate::settings::normalize_shortcut(&hotkey_str);
+fn register_shortcut(app: &AppHandle, hotkey_str: &str) -> Result<(), AppError> {
+    let normalized = crate::settings::normalize_shortcut(hotkey_str);
 
     let shortcut = normalized
         .parse::<Shortcut>()
@@ -224,6 +215,28 @@ fn register_initial_shortcut(app: &AppHandle) -> Result<(), AppError> {
     app.global_shortcut()
         .on_shortcut(shortcut, crate::window::shortcut_handler)
         .map_err(|e| AppError::Shortcut(e.to_string()))?;
+
+    Ok(())
+}
+
+fn register_initial_shortcut(app: &AppHandle) -> Result<(), AppError> {
+
+    let state = app.state::<AppState>();
+
+    let (hotkey_str, open_apps_str) = {
+        let s = state
+            .settings
+            .lock()
+            .map_err(|_| AppError::State("settings poisoned".into()))?;
+        (s.hotkey.clone(), s.open_apps_hotkey.clone())
+    };
+
+    register_shortcut(app, &hotkey_str)?;
+
+    // the open-apps shortcut is best-effort: a failure here must not break the clipboard hotkey
+    if let Err(e) = register_shortcut(app, &open_apps_str) {
+        log::error!("failed to register open-apps global shortcut: {e}");
+    }
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,8 @@ pub fn run() {
             commands::sessions::activate_session,
             commands::sessions::reorder_sessions,
             commands::sessions::pin_item_to_session,
+            commands::apps::list_open_apps,
+            commands::apps::focus_app,
         ])
         .setup(|app| {
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -123,24 +123,45 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while running tauri application")
         .run(|app, event| match event {
+
             tauri::RunEvent::Ready => {
                 if let Err(e) = register_initial_shortcut(app) {
                     log::error!("failed to register initial global shortcut: {e}");
                 }
             }
+
             tauri::RunEvent::Exit => {
+
                 let state = app.state::<AppState>();
+
                 state.shutdown.store(true, Ordering::SeqCst);
 
                 state.monitor_tx.lock().ok().map(|mut g| g.take());
 
-                drop(state.monitor_handles.lock().ok().and_then(|mut g| g.take()));
+                let handles = state.monitor_handles.lock().ok().and_then(|mut g| g.take());
+
+                if let Some((h1, h2)) = handles {
+
+                    let (tx, rx) = std::sync::mpsc::channel::<()>();
+
+                    std::thread::spawn(move || {
+                        let _ = h1.join();
+                        let _ = h2.join();
+                        let _ = tx.send(());
+                    });
+
+                    if rx.recv_timeout(std::time::Duration::from_secs(2)).is_err() {
+                        log::warn!("monitor threads did not exit in 2 s; forcing exit");
+                        std::process::exit(0);
+                    }
+                }
             }
             _ => {}
         });
 }
 
 fn init_app_state(app: &mut tauri::App) -> Result<(), AppError> {
+
     let data_dir = app
         .path()
         .app_data_dir()
@@ -156,15 +177,19 @@ fn init_app_state(app: &mut tauri::App) -> Result<(), AppError> {
     if let Ok(p) = crate::db::db_path(app.handle()) {
         log::info!("db path: {}", p.display());
     }
+
     let session_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
         .unwrap_or(-1);
+
     let history_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM clipboard_history", [], |r| r.get(0))
         .unwrap_or(-1);
+
     log::info!("startup row counts: sessions={session_count} history={history_count}");
 
     let conn_monitor = Connection::open(crate::db::db_path(app.handle())?)?;
+
     conn_monitor.execute_batch("PRAGMA busy_timeout = 5000;")?;
 
     app.manage(AppState {
@@ -180,7 +205,9 @@ fn init_app_state(app: &mut tauri::App) -> Result<(), AppError> {
 }
 
 fn register_initial_shortcut(app: &AppHandle) -> Result<(), AppError> {
+
     let state = app.state::<AppState>();
+
     let hotkey_str = state
         .settings
         .lock()

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -11,6 +11,7 @@ pub struct Settings {
     pub history_limit: u32,
     pub window_width: f64,
     pub window_height: f64,
+    pub tab_shortcut_apps: String,
     pub tab_shortcut_pinned: String,
     pub tab_shortcut_history: String,
     pub tab_shortcut_sessions: String,
@@ -25,9 +26,10 @@ impl Default for Settings {
             history_limit: 20,
             window_width: 400.0,
             window_height: 600.0,
-            tab_shortcut_pinned: format!("{tab_mod}+1"),
-            tab_shortcut_history: format!("{tab_mod}+2"),
-            tab_shortcut_sessions: format!("{tab_mod}+3"),
+            tab_shortcut_apps: format!("{tab_mod}+1"),
+            tab_shortcut_pinned: format!("{tab_mod}+2"),
+            tab_shortcut_history: format!("{tab_mod}+3"),
+            tab_shortcut_sessions: format!("{tab_mod}+4"),
             tab_shortcut_find: format!("{tab_mod}+F"),
         }
     }
@@ -65,6 +67,9 @@ impl Settings {
                 Ok(n) => s.window_height = n,
                 Err(_) => log::warn!("settings migration: invalid window_height {:?}, using default", raw),
             }
+        }
+        if let Some(v) = map.get("tab_shortcut_apps") {
+            s.tab_shortcut_apps = v.clone();
         }
         if let Some(v) = map.get("tab_shortcut_pinned") {
             s.tab_shortcut_pinned = v.clone();
@@ -354,6 +359,7 @@ mod tests {
             history_limit: 200,
             window_width: 50.0,
             window_height: 5000.0,
+            tab_shortcut_apps: "E".to_string(),
             tab_shortcut_pinned: "A".to_string(),
             tab_shortcut_history: "B".to_string(),
             tab_shortcut_sessions: "D".to_string(),

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -24,8 +24,8 @@ impl Default for Settings {
         Self {
             hotkey: "Option+Space".to_string(),
             history_limit: 20,
-            window_width: 400.0,
-            window_height: 600.0,
+            window_width: 600.0,
+            window_height: 700.0,
             tab_shortcut_pinned: format!("{tab_mod}+1"),
             tab_shortcut_history: format!("{tab_mod}+2"),
             tab_shortcut_sessions: format!("{tab_mod}+3"),

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -11,11 +11,11 @@ pub struct Settings {
     pub history_limit: u32,
     pub window_width: f64,
     pub window_height: f64,
-    pub tab_shortcut_apps: String,
     pub tab_shortcut_pinned: String,
     pub tab_shortcut_history: String,
     pub tab_shortcut_sessions: String,
     pub tab_shortcut_find: String,
+    pub open_apps_hotkey: String,
 }
 
 impl Default for Settings {
@@ -26,11 +26,11 @@ impl Default for Settings {
             history_limit: 20,
             window_width: 400.0,
             window_height: 600.0,
-            tab_shortcut_apps: format!("{tab_mod}+1"),
-            tab_shortcut_pinned: format!("{tab_mod}+2"),
-            tab_shortcut_history: format!("{tab_mod}+3"),
-            tab_shortcut_sessions: format!("{tab_mod}+4"),
+            tab_shortcut_pinned: format!("{tab_mod}+1"),
+            tab_shortcut_history: format!("{tab_mod}+2"),
+            tab_shortcut_sessions: format!("{tab_mod}+3"),
             tab_shortcut_find: format!("{tab_mod}+F"),
+            open_apps_hotkey: "Control+Option+Esc".to_string(),
         }
     }
 }
@@ -68,9 +68,6 @@ impl Settings {
                 Err(_) => log::warn!("settings migration: invalid window_height {:?}, using default", raw),
             }
         }
-        if let Some(v) = map.get("tab_shortcut_apps") {
-            s.tab_shortcut_apps = v.clone();
-        }
         if let Some(v) = map.get("tab_shortcut_pinned") {
             s.tab_shortcut_pinned = v.clone();
         }
@@ -82,6 +79,9 @@ impl Settings {
         }
         if let Some(v) = map.get("tab_shortcut_find") {
             s.tab_shortcut_find = v.clone();
+        }
+        if let Some(v) = map.get("open_apps_hotkey") {
+            s.open_apps_hotkey = v.clone();
         }
         s
     }
@@ -270,6 +270,18 @@ mod tests {
     }
 
     #[test]
+    fn open_apps_hotkey_default_present_and_missing() {
+        assert_eq!(Settings::default().open_apps_hotkey, "Control+Option+Esc");
+
+        let mut present = HashMap::new();
+        present.insert("open_apps_hotkey".to_string(), "Control+Shift+A".to_string());
+        assert_eq!(Settings::from_map(present).open_apps_hotkey, "Control+Shift+A");
+
+        let missing = HashMap::new();
+        assert_eq!(Settings::from_map(missing).open_apps_hotkey, "Control+Option+Esc");
+    }
+
+    #[test]
     fn settings_round_trip() {
         use tempfile::TempDir;
 
@@ -359,11 +371,11 @@ mod tests {
             history_limit: 200,
             window_width: 50.0,
             window_height: 5000.0,
-            tab_shortcut_apps: "E".to_string(),
             tab_shortcut_pinned: "A".to_string(),
             tab_shortcut_history: "B".to_string(),
             tab_shortcut_sessions: "D".to_string(),
             tab_shortcut_find: "C".to_string(),
+            open_apps_hotkey: "F".to_string(),
         };
 
         s.validate();

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -2,7 +2,7 @@ use crate::AppState;
 use tauri::{Emitter, Manager, Monitor, PhysicalPosition, WebviewWindow};
 use tauri_plugin_global_shortcut::{Shortcut, ShortcutEvent, ShortcutState};
 
-pub(crate) fn shortcut_handler(app: &tauri::AppHandle, _shortcut: &Shortcut, event: ShortcutEvent) {
+pub(crate) fn shortcut_handler(app: &tauri::AppHandle, shortcut: &Shortcut, event: ShortcutEvent) {
 
     // ignore key-up events
     if event.state() != ShortcutState::Pressed {
@@ -13,13 +13,24 @@ pub(crate) fn shortcut_handler(app: &tauri::AppHandle, _shortcut: &Shortcut, eve
         return;
     };
 
+    // ignore when the window is already visible (the other shortcut is a no-op)
+    if win.is_visible().unwrap_or(false) {
+        return;
+    }
+
     // get cursor position
     let state = app.state::<AppState>();
-    let (width, height) = state
+    let (width, height, open_apps_hotkey) = state
         .settings
         .lock()
-        .map(|s| (s.window_width, s.window_height))
-        .unwrap_or((400.0, 600.0));
+        .map(|s| (s.window_width, s.window_height, s.open_apps_hotkey.clone()))
+        .unwrap_or((400.0, 600.0, String::new()));
+
+    // decide which mode the frontend should render based on which shortcut fired
+    let mode = match crate::settings::normalize_shortcut(&open_apps_hotkey).parse::<Shortcut>() {
+        Ok(apps_shortcut) if shortcut == &apps_shortcut => "apps",
+        _ => "clipboard",
+    };
 
     let Ok(cursor) = app.cursor_position() else {
         return;
@@ -40,7 +51,7 @@ pub(crate) fn shortcut_handler(app: &tauri::AppHandle, _shortcut: &Shortcut, eve
     let _ = win.set_position(tauri::Position::Physical(PhysicalPosition { x, y }));
     let _ = win.show();
     let _ = win.set_focus();
-    let _ = app.emit("main-window-shown", ());
+    let _ = app.emit("main-window-shown", mode);
 }
 
 pub(crate) fn monitor_under_point(win: &WebviewWindow, x: i32, y: i32) -> Option<Monitor> {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ClipX",
-  "version": "0.1.18",
+  "version": "0.1.20",
   "identifier": "com.adriano.clipx",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,8 +14,8 @@
       {
         "label": "main",
         "title": "ClipX",
-        "width": 400,
-        "height": 600,
+        "width": 600,
+        "height": 700,
         "decorations": false,
         "visible": false,
         "backgroundColor": [30, 30, 30, 255],

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -56,6 +56,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "signingIdentity": "ClipX Dev"
+    }
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -133,6 +133,19 @@
   background: #333;
 }
 
+.app-item {
+  justify-content: flex-start;
+  gap: 0.5rem;
+}
+
+.app-index {
+  min-width: 1.1rem;
+  text-align: center;
+  color: #888;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+}
+
 .drag-handle {
   cursor: grab;
   margin-right: 0.5rem;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useMemo, useCallback } from "react";
+import { useRef, useState, useMemo, useCallback, useEffect } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import {
@@ -9,6 +9,8 @@ import {
   getClipboard,
   getSetting,
   activateSession,
+  listOpenApps,
+  focusApp,
   logError,
 } from "./services/clipboardService";
 
@@ -17,6 +19,7 @@ import { IS_MAC } from "./utils/shortcuts";
 
 const TAB_MOD = IS_MAC ? "Command" : "Alt";
 
+import AppsTab from "./components/AppsTab";
 import PinnedTab from "./components/PinnedTab";
 import HistoryTab from "./components/HistoryTab";
 import SessionsTab from "./components/SessionsTab";
@@ -24,22 +27,26 @@ import SessionsTab from "./components/SessionsTab";
 import "./App.css";
 
 function App() {
-  const [activeTab, setActiveTab] = useState("pinned");
+  const [activeTab, setActiveTab] = useState("apps");
   const [history, setHistory] = useState([]);
   const [pinned, setPinned] = useState([]);
   const [globalPinned, setGlobalPinned] = useState([]);
   const [sessions, setSessions] = useState([]);
+  const [apps, setApps] = useState([]);
   const [currentClipboard, setCurrentClipboard] = useState("");
   const [historySearch, setHistorySearch] = useState("");
   const [pinnedSearch, setPinnedSearch] = useState("");
   const [sessionsSearch, setSessionsSearch] = useState("");
-  const [tabShortcutPinned, setTabShortcutPinned] = useState(`${TAB_MOD}+1`);
-  const [tabShortcutHistory, setTabShortcutHistory] = useState(`${TAB_MOD}+2`);
-  const [tabShortcutSessions, setTabShortcutSessions] = useState(`${TAB_MOD}+3`);
+  const [appsSearch, setAppsSearch] = useState("");
+  const [tabShortcutApps, setTabShortcutApps] = useState(`${TAB_MOD}+1`);
+  const [tabShortcutPinned, setTabShortcutPinned] = useState(`${TAB_MOD}+2`);
+  const [tabShortcutHistory, setTabShortcutHistory] = useState(`${TAB_MOD}+3`);
+  const [tabShortcutSessions, setTabShortcutSessions] = useState(`${TAB_MOD}+4`);
   const [tabShortcutFind, setTabShortcutFind] = useState(`${TAB_MOD}+F`);
   const pinnedSearchRef = useRef(null);
   const historySearchRef = useRef(null);
   const sessionsSearchRef = useRef(null);
+  const appsSearchRef = useRef(null);
 
   const filteredHistory = useMemo(
     () => history.filter((item) => item.content.toLowerCase().includes(historySearch.toLowerCase())),
@@ -60,6 +67,14 @@ function App() {
     () => sessions.filter((s) => s.name.toLowerCase().includes(sessionsSearch.toLowerCase())),
     [sessions, sessionsSearch]
   );
+
+  const filteredApps = useMemo(() => {
+    const tokens = appsSearch.toLowerCase().split(/\s+/).filter(Boolean);
+    return apps.filter((a) => {
+      const name = a.name.toLowerCase();
+      return tokens.every((t) => name.includes(t));
+    });
+  }, [apps, appsSearch]);
 
   const pinnedSet = useMemo(() => new Set(globalPinned.map((p) => p.content)), [globalPinned]);
 
@@ -106,12 +121,14 @@ function App() {
 
   const loadTabShortcuts = useCallback(async () => {
     try {
-      const [pinned, history, sessions, find] = await Promise.all([
+      const [apps, pinned, history, sessions, find] = await Promise.all([
+        getSetting("tab_shortcut_apps"),
         getSetting("tab_shortcut_pinned"),
         getSetting("tab_shortcut_history"),
         getSetting("tab_shortcut_sessions"),
         getSetting("tab_shortcut_find"),
       ]);
+      setTabShortcutApps(apps);
       setTabShortcutPinned(pinned);
       setTabShortcutHistory(history);
       setTabShortcutSessions(sessions);
@@ -121,16 +138,39 @@ function App() {
     }
   }, []);
 
+  const loadApps = useCallback(async () => {
+    try {
+      const a = await listOpenApps();
+      setApps(a);
+    } catch (e) {
+      await logError("error", `Failed to load apps: ${e}`);
+    }
+  }, []);
+
   const clearSearch = useCallback(() => {
     setHistorySearch("");
     setPinnedSearch("");
     setSessionsSearch("");
+    setAppsSearch("");
   }, []);
 
   const handleCopy = useCallback(async (text) => {
     await writeText(text);
     await getCurrentWindow().hide();
   }, []);
+
+  const handleSelectApp = useCallback(async (id) => {
+    try {
+      await focusApp(id);
+      await getCurrentWindow().hide();
+    } catch (e) {
+      await logError("error", `Failed to focus app: ${e}`);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadApps();
+  }, [loadApps]);
 
   const handleActivateSession = useCallback(async (id) => {
     try {
@@ -144,23 +184,28 @@ function App() {
   useAppEvents({
     activeTab,
     setActiveTab,
+    tabShortcutApps,
     tabShortcutPinned,
     tabShortcutHistory,
     tabShortcutSessions,
     tabShortcutFind,
+    filteredApps,
     filteredPinned,
     filteredHistory,
     filteredSessions,
     pinnedSearchRef,
     historySearchRef,
     sessionsSearchRef,
+    appsSearchRef,
     onLoadData: loadData,
+    onLoadApps: loadApps,
     onLoadHistory: loadHistory,
     onLoadClipboard: loadClipboard,
     onLoadTabShortcuts: loadTabShortcuts,
     onClearSearch: clearSearch,
     onCopy: handleCopy,
     onActivateSession: handleActivateSession,
+    onFocusApp: handleSelectApp,
   });
 
   return (
@@ -170,6 +215,12 @@ function App() {
         <h1>ClipX</h1>
       </div>
       <div className="tabs">
+        <button
+          className={activeTab === "apps" ? "active" : ""}
+          onClick={() => setActiveTab("apps")}
+        >
+          Apps
+        </button>
         <button
           className={activeTab === "pinned" ? "active" : ""}
           onClick={() => setActiveTab("pinned")}
@@ -189,6 +240,15 @@ function App() {
           Sessions
         </button>
       </div>
+      {activeTab === "apps" && (
+        <AppsTab
+          filteredApps={filteredApps}
+          appsSearch={appsSearch}
+          setAppsSearch={setAppsSearch}
+          appsSearchRef={appsSearchRef}
+          onSelect={handleSelectApp}
+        />
+      )}
       {activeTab === "pinned" && (
         <PinnedTab
           pinned={pinned}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,8 @@ import SessionsTab from "./components/SessionsTab";
 import "./App.css";
 
 function App() {
-  const [activeTab, setActiveTab] = useState("apps");
+  const [mode, setMode] = useState("clipboard");
+  const [activeTab, setActiveTab] = useState("pinned");
   const [history, setHistory] = useState([]);
   const [pinned, setPinned] = useState([]);
   const [globalPinned, setGlobalPinned] = useState([]);
@@ -38,10 +39,9 @@ function App() {
   const [pinnedSearch, setPinnedSearch] = useState("");
   const [sessionsSearch, setSessionsSearch] = useState("");
   const [appsSearch, setAppsSearch] = useState("");
-  const [tabShortcutApps, setTabShortcutApps] = useState(`${TAB_MOD}+1`);
-  const [tabShortcutPinned, setTabShortcutPinned] = useState(`${TAB_MOD}+2`);
-  const [tabShortcutHistory, setTabShortcutHistory] = useState(`${TAB_MOD}+3`);
-  const [tabShortcutSessions, setTabShortcutSessions] = useState(`${TAB_MOD}+4`);
+  const [tabShortcutPinned, setTabShortcutPinned] = useState(`${TAB_MOD}+1`);
+  const [tabShortcutHistory, setTabShortcutHistory] = useState(`${TAB_MOD}+2`);
+  const [tabShortcutSessions, setTabShortcutSessions] = useState(`${TAB_MOD}+3`);
   const [tabShortcutFind, setTabShortcutFind] = useState(`${TAB_MOD}+F`);
   const pinnedSearchRef = useRef(null);
   const historySearchRef = useRef(null);
@@ -121,14 +121,12 @@ function App() {
 
   const loadTabShortcuts = useCallback(async () => {
     try {
-      const [apps, pinned, history, sessions, find] = await Promise.all([
-        getSetting("tab_shortcut_apps"),
+      const [pinned, history, sessions, find] = await Promise.all([
         getSetting("tab_shortcut_pinned"),
         getSetting("tab_shortcut_history"),
         getSetting("tab_shortcut_sessions"),
         getSetting("tab_shortcut_find"),
       ]);
-      setTabShortcutApps(apps);
       setTabShortcutPinned(pinned);
       setTabShortcutHistory(history);
       setTabShortcutSessions(sessions);
@@ -184,7 +182,8 @@ function App() {
   useAppEvents({
     activeTab,
     setActiveTab,
-    tabShortcutApps,
+    mode,
+    onSetMode: setMode,
     tabShortcutPinned,
     tabShortcutHistory,
     tabShortcutSessions,
@@ -214,13 +213,18 @@ function App() {
         <img src="/icon.png" alt="ClipX" className="app-icon" />
         <h1>ClipX</h1>
       </div>
+      {mode === "apps" && (
+        <AppsTab
+          filteredApps={filteredApps}
+          appsSearch={appsSearch}
+          setAppsSearch={setAppsSearch}
+          appsSearchRef={appsSearchRef}
+          onSelect={handleSelectApp}
+        />
+      )}
+      {mode === "clipboard" && (
+        <>
       <div className="tabs">
-        <button
-          className={activeTab === "apps" ? "active" : ""}
-          onClick={() => setActiveTab("apps")}
-        >
-          Apps
-        </button>
         <button
           className={activeTab === "pinned" ? "active" : ""}
           onClick={() => setActiveTab("pinned")}
@@ -240,15 +244,6 @@ function App() {
           Sessions
         </button>
       </div>
-      {activeTab === "apps" && (
-        <AppsTab
-          filteredApps={filteredApps}
-          appsSearch={appsSearch}
-          setAppsSearch={setAppsSearch}
-          appsSearchRef={appsSearchRef}
-          onSelect={handleSelectApp}
-        />
-      )}
       {activeTab === "pinned" && (
         <PinnedTab
           pinned={pinned}
@@ -283,6 +278,8 @@ function App() {
           sessionsSearchRef={sessionsSearchRef}
           onDataChanged={loadData}
         />
+      )}
+        </>
       )}
     </main>
   );

--- a/src/components/AppsTab.jsx
+++ b/src/components/AppsTab.jsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 export default function AppsTab({
   filteredApps,
   appsSearch,
@@ -5,6 +7,10 @@ export default function AppsTab({
   appsSearchRef,
   onSelect,
 }) {
+  useEffect(() => {
+    appsSearchRef.current?.focus();
+  }, [appsSearchRef]);
+
   return (
     <>
       <div className="search-bar">
@@ -32,8 +38,9 @@ export default function AppsTab({
       </div>
       <div className="list">
         {filteredApps.length === 0 && <div className="empty">No apps</div>}
-        {filteredApps.map((app) => (
-          <div key={app.id} className="item" onClick={() => onSelect(app.id)}>
+        {filteredApps.map((app, i) => (
+          <div key={app.id} className="item app-item" onClick={() => onSelect(app.id)}>
+            <span className="app-index">{i < 9 ? i + 1 : ""}</span>
             <span className="session-name">{app.name}</span>
           </div>
         ))}

--- a/src/components/AppsTab.jsx
+++ b/src/components/AppsTab.jsx
@@ -1,0 +1,43 @@
+export default function AppsTab({
+  filteredApps,
+  appsSearch,
+  setAppsSearch,
+  appsSearchRef,
+  onSelect,
+}) {
+  return (
+    <>
+      <div className="search-bar">
+        <input
+          ref={appsSearchRef}
+          className="search-input"
+          type="text"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+          placeholder="Search apps..."
+          value={appsSearch}
+          onChange={(e) => setAppsSearch(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && filteredApps.length > 0) {
+              e.preventDefault();
+              onSelect(filteredApps[0].id);
+            }
+            if (e.key === "Escape") {
+              e.stopPropagation();
+              e.target.blur();
+            }
+          }}
+        />
+      </div>
+      <div className="list">
+        {filteredApps.length === 0 && <div className="empty">No apps</div>}
+        {filteredApps.map((app) => (
+          <div key={app.id} className="item" onClick={() => onSelect(app.id)}>
+            <span className="session-name">{app.name}</span>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/HistoryTab.jsx
+++ b/src/components/HistoryTab.jsx
@@ -55,6 +55,9 @@ export default function HistoryTab({
           ref={historySearchRef}
           className="search-input"
           type="text"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
           placeholder="Search history..."
           value={historySearch}
           onChange={(e) => setHistorySearch(e.target.value)}

--- a/src/components/PinnedTab.jsx
+++ b/src/components/PinnedTab.jsx
@@ -85,6 +85,9 @@ export default function PinnedTab({
           ref={pinnedSearchRef}
           className="search-input"
           type="text"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
           placeholder="Search pinned..."
           value={pinnedSearch}
           onChange={(e) => setPinnedSearch(e.target.value)}

--- a/src/components/SessionsTab.jsx
+++ b/src/components/SessionsTab.jsx
@@ -70,6 +70,9 @@ export default function SessionsTab({
           ref={sessionsSearchRef}
           className="search-input"
           type="text"
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
           placeholder="Search sessions..."
           value={sessionsSearch}
           onChange={(e) => setSessionsSearch(e.target.value)}

--- a/src/components/Settings.css
+++ b/src/components/Settings.css
@@ -253,26 +253,7 @@ body {
   padding: 10px 12px;
   color: var(--text);
   font: 500 14px var(--font-mono);
-  -moz-appearance: textfield;
 }
-.num input::-webkit-outer-spin-button,
-.num input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
-
-.num-steppers { display: flex; flex-direction: column; gap: 1px; }
-.num-steppers button {
-  width: 22px;
-  height: 16px;
-  background: var(--bg-3);
-  border: 1px solid var(--border-2);
-  color: var(--text-2);
-  border-radius: 4px;
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  transition: all 120ms;
-}
-.num-steppers button:hover { background: var(--bg-hover); color: var(--text); }
-.num-steppers button:active { transform: translateY(0.5px); }
 
 /* ── METER ───────────────────────────────────────────── */
 .meter { margin-top: 4px; }

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -132,28 +132,36 @@ function HotkeyField({ label, hint, value, onChange }) {
   );
 }
 
-function NumberField({ label, hint, value, onChange, min, max, step = 1 }) {
-  const clamp = (v) => Math.min(max ?? Infinity, Math.max(min ?? -Infinity, v));
+function NumberField({ label, hint, value, onChange, min, max }) {
+  const [draft, setDraft] = useState(String(value));
+
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  const commit = () => {
+    const n = Number(draft);
+    if (draft.trim() === "" || Number.isNaN(n)) {
+      setDraft(String(value));
+      return;
+    }
+    const clamped = Math.min(max ?? Infinity, Math.max(min ?? -Infinity, n));
+    setDraft(String(clamped));
+    if (clamped !== value) onChange(clamped);
+  };
+
   return (
     <div className="field">
       <div className="field-label">{label}</div>
       <div className="num">
         <input
-          type="number"
-          value={value}
-          min={min}
-          max={max}
-          step={step}
-          onChange={(e) => onChange(clamp(Number(e.target.value)))}
+          type="text"
+          inputMode="numeric"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => { if (e.key === "Enter") e.target.blur(); }}
         />
-        <div className="num-steppers">
-          <button type="button" onClick={() => onChange(clamp(value + step))} aria-label="Increase">
-            <svg width="8" height="5" viewBox="0 0 8 5"><path d="M1 4l3-3 3 3" stroke="currentColor" strokeWidth="1.3" fill="none" strokeLinecap="round" /></svg>
-          </button>
-          <button type="button" onClick={() => onChange(clamp(value - step))} aria-label="Decrease">
-            <svg width="8" height="5" viewBox="0 0 8 5"><path d="M1 1l3 3 3-3" stroke="currentColor" strokeWidth="1.3" fill="none" strokeLinecap="round" /></svg>
-          </button>
-        </div>
       </div>
       {hint && <div className="field-hint">{hint}</div>}
     </div>
@@ -317,8 +325,8 @@ function Settings() {
     tabShortcutSessions: `${TAB_MOD}+3`,
     tabShortcutFind: `${TAB_MOD}+F`,
     historyLimit: 20,
-    windowWidth: 400,
-    windowHeight: 600,
+    windowWidth: 600,
+    windowHeight: 700,
   });
 
   const set = (k, v) => {
@@ -353,8 +361,8 @@ function Settings() {
         safeGet("tab_shortcut_sessions", `${TAB_MOD}+3`),
         safeGet("tab_shortcut_find", `${TAB_MOD}+F`),
         safeGet("history_limit", 20, Number),
-        safeGet("window_width", 400, (v) => Number(v) || 400),
-        safeGet("window_height", 600, (v) => Number(v) || 600),
+        safeGet("window_width", 600, (v) => Number(v) || 600),
+        safeGet("window_height", 700, (v) => Number(v) || 700),
       ]);
       setS({ hotkey, openAppsHotkey: openApps, tabShortcutPinned: pinned, tabShortcutHistory: history, tabShortcutSessions: sessions, tabShortcutFind: find, historyLimit: limit, windowWidth: width, windowHeight: height });
     };

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -218,6 +218,7 @@ function HotkeysPanel({ s, set }) {
         <h3>In-app Shortcuts</h3>
         <p>Used when ClipX is focused.</p>
       </div>
+      <HotkeyField label="Switch to Apps" hint="Jump to the Apps tab." value={s.tabShortcutApps} onChange={(v) => set("tabShortcutApps", v)} />
       <HotkeyField label="Switch to Pinned" hint="Jump to the Pinned tab." value={s.tabShortcutPinned} onChange={(v) => set("tabShortcutPinned", v)} />
       <HotkeyField label="Switch to History" hint="Jump to the History tab." value={s.tabShortcutHistory} onChange={(v) => set("tabShortcutHistory", v)} />
       <HotkeyField label="Switch to Sessions" hint="Jump to the Sessions tab." value={s.tabShortcutSessions} onChange={(v) => set("tabShortcutSessions", v)} />
@@ -304,9 +305,10 @@ function Settings() {
 
   const [s, setS] = useState({
     hotkey: "",
-    tabShortcutPinned: `${TAB_MOD}+1`,
-    tabShortcutHistory: `${TAB_MOD}+2`,
-    tabShortcutSessions: `${TAB_MOD}+3`,
+    tabShortcutApps: `${TAB_MOD}+1`,
+    tabShortcutPinned: `${TAB_MOD}+2`,
+    tabShortcutHistory: `${TAB_MOD}+3`,
+    tabShortcutSessions: `${TAB_MOD}+4`,
     tabShortcutFind: `${TAB_MOD}+F`,
     historyLimit: 20,
     windowWidth: 400,
@@ -337,17 +339,18 @@ function Settings() {
           return fallback;
         }
       };
-      const [hotkey, pinned, history, sessions, find, limit, width, height] = await Promise.all([
+      const [hotkey, apps, pinned, history, sessions, find, limit, width, height] = await Promise.all([
         safeGet("hotkey", "Option+Space"),
-        safeGet("tab_shortcut_pinned", `${TAB_MOD}+1`),
-        safeGet("tab_shortcut_history", `${TAB_MOD}+2`),
-        safeGet("tab_shortcut_sessions", `${TAB_MOD}+3`),
+        safeGet("tab_shortcut_apps", `${TAB_MOD}+1`),
+        safeGet("tab_shortcut_pinned", `${TAB_MOD}+2`),
+        safeGet("tab_shortcut_history", `${TAB_MOD}+3`),
+        safeGet("tab_shortcut_sessions", `${TAB_MOD}+4`),
         safeGet("tab_shortcut_find", `${TAB_MOD}+F`),
         safeGet("history_limit", 20, Number),
         safeGet("window_width", 400, (v) => Number(v) || 400),
         safeGet("window_height", 600, (v) => Number(v) || 600),
       ]);
-      setS({ hotkey, tabShortcutPinned: pinned, tabShortcutHistory: history, tabShortcutSessions: sessions, tabShortcutFind: find, historyLimit: limit, windowWidth: width, windowHeight: height });
+      setS({ hotkey, tabShortcutApps: apps, tabShortcutPinned: pinned, tabShortcutHistory: history, tabShortcutSessions: sessions, tabShortcutFind: find, historyLimit: limit, windowWidth: width, windowHeight: height });
     };
     load();
   }, []);
@@ -357,6 +360,7 @@ function Settings() {
     const errors = [];
     const attempt = async (fn) => { try { await fn(); } catch (e) { errors.push(String(e)); } };
     await attempt(() => updateShortcut(s.hotkey));
+    await attempt(() => setSetting("tab_shortcut_apps", s.tabShortcutApps));
     await attempt(() => setSetting("tab_shortcut_pinned", s.tabShortcutPinned));
     await attempt(() => setSetting("tab_shortcut_history", s.tabShortcutHistory));
     await attempt(() => setSetting("tab_shortcut_sessions", s.tabShortcutSessions));

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -4,6 +4,7 @@ import {
   getSetting,
   setSetting,
   updateShortcut,
+  updateOpenAppsShortcut,
   applyWindowSize,
   logError,
 } from "../services/clipboardService";
@@ -214,11 +215,16 @@ function HotkeysPanel({ s, set }) {
         value={s.hotkey}
         onChange={(v) => set("hotkey", v)}
       />
+      <HotkeyField
+        label="Open List of Apps"
+        hint="System-wide hotkey to open the list of running apps."
+        value={s.openAppsHotkey}
+        onChange={(v) => set("openAppsHotkey", v)}
+      />
       <div className="section-header">
         <h3>In-app Shortcuts</h3>
         <p>Used when ClipX is focused.</p>
       </div>
-      <HotkeyField label="Switch to Apps" hint="Jump to the Apps tab." value={s.tabShortcutApps} onChange={(v) => set("tabShortcutApps", v)} />
       <HotkeyField label="Switch to Pinned" hint="Jump to the Pinned tab." value={s.tabShortcutPinned} onChange={(v) => set("tabShortcutPinned", v)} />
       <HotkeyField label="Switch to History" hint="Jump to the History tab." value={s.tabShortcutHistory} onChange={(v) => set("tabShortcutHistory", v)} />
       <HotkeyField label="Switch to Sessions" hint="Jump to the Sessions tab." value={s.tabShortcutSessions} onChange={(v) => set("tabShortcutSessions", v)} />
@@ -305,10 +311,10 @@ function Settings() {
 
   const [s, setS] = useState({
     hotkey: "",
-    tabShortcutApps: `${TAB_MOD}+1`,
-    tabShortcutPinned: `${TAB_MOD}+2`,
-    tabShortcutHistory: `${TAB_MOD}+3`,
-    tabShortcutSessions: `${TAB_MOD}+4`,
+    openAppsHotkey: "Control+Option+Esc",
+    tabShortcutPinned: `${TAB_MOD}+1`,
+    tabShortcutHistory: `${TAB_MOD}+2`,
+    tabShortcutSessions: `${TAB_MOD}+3`,
     tabShortcutFind: `${TAB_MOD}+F`,
     historyLimit: 20,
     windowWidth: 400,
@@ -339,18 +345,18 @@ function Settings() {
           return fallback;
         }
       };
-      const [hotkey, apps, pinned, history, sessions, find, limit, width, height] = await Promise.all([
+      const [hotkey, openApps, pinned, history, sessions, find, limit, width, height] = await Promise.all([
         safeGet("hotkey", "Option+Space"),
-        safeGet("tab_shortcut_apps", `${TAB_MOD}+1`),
-        safeGet("tab_shortcut_pinned", `${TAB_MOD}+2`),
-        safeGet("tab_shortcut_history", `${TAB_MOD}+3`),
-        safeGet("tab_shortcut_sessions", `${TAB_MOD}+4`),
+        safeGet("open_apps_hotkey", "Control+Option+Esc"),
+        safeGet("tab_shortcut_pinned", `${TAB_MOD}+1`),
+        safeGet("tab_shortcut_history", `${TAB_MOD}+2`),
+        safeGet("tab_shortcut_sessions", `${TAB_MOD}+3`),
         safeGet("tab_shortcut_find", `${TAB_MOD}+F`),
         safeGet("history_limit", 20, Number),
         safeGet("window_width", 400, (v) => Number(v) || 400),
         safeGet("window_height", 600, (v) => Number(v) || 600),
       ]);
-      setS({ hotkey, tabShortcutApps: apps, tabShortcutPinned: pinned, tabShortcutHistory: history, tabShortcutSessions: sessions, tabShortcutFind: find, historyLimit: limit, windowWidth: width, windowHeight: height });
+      setS({ hotkey, openAppsHotkey: openApps, tabShortcutPinned: pinned, tabShortcutHistory: history, tabShortcutSessions: sessions, tabShortcutFind: find, historyLimit: limit, windowWidth: width, windowHeight: height });
     };
     load();
   }, []);
@@ -360,7 +366,7 @@ function Settings() {
     const errors = [];
     const attempt = async (fn) => { try { await fn(); } catch (e) { errors.push(String(e)); } };
     await attempt(() => updateShortcut(s.hotkey));
-    await attempt(() => setSetting("tab_shortcut_apps", s.tabShortcutApps));
+    await attempt(() => updateOpenAppsShortcut(s.openAppsHotkey));
     await attempt(() => setSetting("tab_shortcut_pinned", s.tabShortcutPinned));
     await attempt(() => setSetting("tab_shortcut_history", s.tabShortcutHistory));
     await attempt(() => setSetting("tab_shortcut_sessions", s.tabShortcutSessions));

--- a/src/hooks/useAppEvents.js
+++ b/src/hooks/useAppEvents.js
@@ -8,23 +8,28 @@ import { EVENTS } from "../constants/events";
 export function useAppEvents({
   activeTab,
   setActiveTab,
+  tabShortcutApps,
   tabShortcutPinned,
   tabShortcutHistory,
   tabShortcutSessions,
   tabShortcutFind,
+  filteredApps,
   filteredPinned,
   filteredHistory,
   filteredSessions,
   pinnedSearchRef,
   historySearchRef,
   sessionsSearchRef,
+  appsSearchRef,
   onLoadData,
+  onLoadApps,
   onLoadHistory,
   onLoadClipboard,
   onLoadTabShortcuts,
   onClearSearch,
   onCopy,
   onActivateSession,
+  onFocusApp,
 }) {
   useEffect(() => {
     onLoadData();
@@ -61,6 +66,7 @@ export function useAppEvents({
       const u3 = await listen("main-window-shown", () => {
         onClearSearch();
         onLoadData();
+        onLoadApps();
       });
 
       if (cancelled) { u3(); return; }
@@ -83,7 +89,7 @@ export function useAppEvents({
       clearTimeout(retryTimer);
       unlisteners.forEach((fn) => fn());
     };
-  }, [onLoadData, onLoadHistory, onLoadClipboard, onLoadTabShortcuts, onClearSearch]);
+  }, [onLoadData, onLoadApps, onLoadHistory, onLoadClipboard, onLoadTabShortcuts, onClearSearch]);
 
   useEffect(() => {
     const onKey = async (e) => {
@@ -101,7 +107,10 @@ export function useAppEvents({
 
       if (tag === "INPUT" || tag === "TEXTAREA") return;
 
-      if (matchesShortcut(e, tabShortcutPinned)) {
+      if (matchesShortcut(e, tabShortcutApps)) {
+        e.preventDefault();
+        setActiveTab("apps");
+      } else if (matchesShortcut(e, tabShortcutPinned)) {
         e.preventDefault();
         setActiveTab("pinned");
       } else if (matchesShortcut(e, tabShortcutHistory)) {
@@ -114,7 +123,7 @@ export function useAppEvents({
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [tabShortcutPinned, tabShortcutHistory, tabShortcutSessions, setActiveTab]);
+  }, [tabShortcutApps, tabShortcutPinned, tabShortcutHistory, tabShortcutSessions, setActiveTab]);
 
   useEffect(() => {
     const onKey = (e) => {
@@ -128,6 +137,8 @@ export function useAppEvents({
           ? pinnedSearchRef
           : activeTab === "sessions"
           ? sessionsSearchRef
+          : activeTab === "apps"
+          ? appsSearchRef
           : historySearchRef;
 
       ref.current?.focus();
@@ -135,7 +146,7 @@ export function useAppEvents({
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [tabShortcutFind, activeTab, pinnedSearchRef, historySearchRef, sessionsSearchRef]);
+  }, [tabShortcutFind, activeTab, pinnedSearchRef, historySearchRef, sessionsSearchRef, appsSearchRef]);
 
   useEffect(() => {
 
@@ -193,6 +204,12 @@ export function useAppEvents({
 
         const index = num - 1;
 
+        if (activeTab === "apps" && index < filteredApps.length) {
+          e.preventDefault();
+          onFocusApp(filteredApps[index].id);
+          return;
+        }
+
         if (activeTab === "sessions" && index < filteredSessions.length) {
           e.preventDefault();
           onActivateSession(filteredSessions[index].id);
@@ -210,5 +227,5 @@ export function useAppEvents({
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [activeTab, filteredPinned, filteredHistory, filteredSessions, onCopy, onActivateSession]);
+  }, [activeTab, filteredApps, filteredPinned, filteredHistory, filteredSessions, onCopy, onActivateSession, onFocusApp]);
 }

--- a/src/hooks/useAppEvents.js
+++ b/src/hooks/useAppEvents.js
@@ -8,7 +8,8 @@ import { EVENTS } from "../constants/events";
 export function useAppEvents({
   activeTab,
   setActiveTab,
-  tabShortcutApps,
+  mode,
+  onSetMode,
   tabShortcutPinned,
   tabShortcutHistory,
   tabShortcutSessions,
@@ -63,10 +64,15 @@ export function useAppEvents({
 
       unlisteners.push(u2);
 
-      const u3 = await listen("main-window-shown", () => {
+      const u3 = await listen("main-window-shown", (event) => {
+        const nextMode = event.payload === "apps" ? "apps" : "clipboard";
+        onSetMode(nextMode);
         onClearSearch();
         onLoadData();
         onLoadApps();
+        if (nextMode === "apps") {
+          setTimeout(() => appsSearchRef.current?.focus(), 0);
+        }
       });
 
       if (cancelled) { u3(); return; }
@@ -89,7 +95,7 @@ export function useAppEvents({
       clearTimeout(retryTimer);
       unlisteners.forEach((fn) => fn());
     };
-  }, [onLoadData, onLoadApps, onLoadHistory, onLoadClipboard, onLoadTabShortcuts, onClearSearch]);
+  }, [onLoadData, onLoadApps, onLoadHistory, onLoadClipboard, onLoadTabShortcuts, onClearSearch, onSetMode, appsSearchRef]);
 
   useEffect(() => {
     const onKey = async (e) => {
@@ -103,14 +109,13 @@ export function useAppEvents({
 
     const onKey = (e) => {
 
+      if (mode !== "clipboard") return;
+
       const tag = e.target.tagName;
 
       if (tag === "INPUT" || tag === "TEXTAREA") return;
 
-      if (matchesShortcut(e, tabShortcutApps)) {
-        e.preventDefault();
-        setActiveTab("apps");
-      } else if (matchesShortcut(e, tabShortcutPinned)) {
+      if (matchesShortcut(e, tabShortcutPinned)) {
         e.preventDefault();
         setActiveTab("pinned");
       } else if (matchesShortcut(e, tabShortcutHistory)) {
@@ -123,10 +128,12 @@ export function useAppEvents({
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [tabShortcutApps, tabShortcutPinned, tabShortcutHistory, tabShortcutSessions, setActiveTab]);
+  }, [mode, tabShortcutPinned, tabShortcutHistory, tabShortcutSessions, setActiveTab]);
 
   useEffect(() => {
     const onKey = (e) => {
+
+      if (mode !== "clipboard") return;
 
       if (!matchesShortcut(e, tabShortcutFind)) return;
 
@@ -137,8 +144,6 @@ export function useAppEvents({
           ? pinnedSearchRef
           : activeTab === "sessions"
           ? sessionsSearchRef
-          : activeTab === "apps"
-          ? appsSearchRef
           : historySearchRef;
 
       ref.current?.focus();
@@ -146,7 +151,7 @@ export function useAppEvents({
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [tabShortcutFind, activeTab, pinnedSearchRef, historySearchRef, sessionsSearchRef, appsSearchRef]);
+  }, [mode, tabShortcutFind, activeTab, pinnedSearchRef, historySearchRef, sessionsSearchRef]);
 
   useEffect(() => {
 
@@ -196,6 +201,8 @@ export function useAppEvents({
 
       const tag = e.target.tagName;
 
+      if (mode !== "clipboard") return;
+
       if (tag === "INPUT" || tag === "TEXTAREA") return;
 
       const num = parseInt(e.key);
@@ -203,12 +210,6 @@ export function useAppEvents({
       if (num >= 1 && num <= 5 && !e.metaKey && !e.ctrlKey && !e.altKey) {
 
         const index = num - 1;
-
-        if (activeTab === "apps" && index < filteredApps.length) {
-          e.preventDefault();
-          onFocusApp(filteredApps[index].id);
-          return;
-        }
 
         if (activeTab === "sessions" && index < filteredSessions.length) {
           e.preventDefault();
@@ -227,5 +228,33 @@ export function useAppEvents({
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [activeTab, filteredApps, filteredPinned, filteredHistory, filteredSessions, onCopy, onActivateSession, onFocusApp]);
+  }, [mode, activeTab, filteredPinned, filteredHistory, filteredSessions, onCopy, onActivateSession]);
+
+  useEffect(() => {
+
+    const onKey = (e) => {
+
+      if (mode !== "apps") return;
+
+      const tag = e.target.tagName;
+
+      // number keys only act once the search box has been blurred (via Esc)
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+
+      const num = parseInt(e.key);
+
+      if (num >= 1 && num <= 9 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+
+        const index = num - 1;
+
+        if (index < filteredApps.length) {
+          e.preventDefault();
+          onFocusApp(filteredApps[index].id);
+        }
+      }
+    };
+
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [mode, filteredApps, onFocusApp]);
 }

--- a/src/services/clipboardService.js
+++ b/src/services/clipboardService.js
@@ -41,3 +41,7 @@ export const activateSession = (id) => invoke("activate_session", { id });
 export const reorderSessions = (items) => invoke("reorder_sessions", { items });
 
 export const pinItemToSession = (content, sessionId, description) => invoke("pin_item_to_session", { content, sessionId, description });
+
+export const listOpenApps = () => invoke("list_open_apps");
+
+export const focusApp = (id) => invoke("focus_app", { id });

--- a/src/services/clipboardService.js
+++ b/src/services/clipboardService.js
@@ -26,6 +26,8 @@ export const reorderPinned = (items) => invoke("reorder_pinned", { items });
 
 export const updateShortcut = (shortcut) => invoke("update_shortcut", { shortcut });
 
+export const updateOpenAppsShortcut = (shortcut) => invoke("update_open_apps_shortcut", { shortcut });
+
 export const applyWindowSize = () => invoke("apply_window_size");
 
 export const logError = (level, message) => invoke("log_frontend_error", { level, message });


### PR DESCRIPTION
# Apps tab: list, search, and switch to open application windows

## Summary

Adds a new **Apps** tab (now the default/first tab, before Pinned | History | Sessions)
that lists every open application window, lets you filter them by name, and switches
to the exact window you pick - similar to Command+Tab but searchable and per-window.

## Features

- **New Apps tab**, first in the tab order: `Apps | Pinned | History | Sessions`.
  It is the default tab on open.
- **Live window list**: one row per open window, shown as `App - window title`
  (e.g. `Code - project-a`, `Google Chrome - Gmail`). Apps with multiple windows
  appear once per window so you can target a specific instance.
- **Search / filter** with an input box like the other tabs. Matching is
  **token AND**: the query is split on spaces and an item matches only if it
  contains *all* tokens, in any order. Example: `Code mine specs` matches
  `Code - ai-mine-specs`.
- **Select to focus**:
  - Click a row, or
  - Press `1`-`5` to pick the Nth filtered row, or
  - Press `Enter` to pick the first filtered row.
  On select, that window is brought to the front and the ClipX window hides.
- **Keyboard shortcut** to jump to the tab. Shortcuts were renumbered to make
  room for Apps:
  - Apps `Cmd+1`, Pinned `Cmd+2`, History `Cmd+3`, Sessions `Cmd+4`
    (Windows: `Alt+` instead of `Cmd+`).
  - The Settings screen gained a "Switch to Apps" hotkey field.
- **Search box polish**: disabled the browser autocomplete/autofill dropdown
  (`autoComplete=off`, `autoCorrect=off`, `spellCheck=false`) on all four search
  inputs (Apps, Pinned, History, Sessions).

## Performance

- The list is **cached**: it loads once on launch and again each time the ClipX
  window is shown (the `main-window-shown` event), not on every tab switch.
  Switching back to the Apps tab is instant.
- The backend commands (`list_open_apps`, `focus_app`) are **async**, so the work
  runs off the main thread and never freezes the UI / window positioning.

## Implementation

### Backend (Rust / Tauri v2)

- New file `src-tauri/src/commands/apps.rs` with two commands:
  - `list_open_apps() -> Vec<OpenApp { name, id }>`
  - `focus_app(id)`
  - `id` packs `"<process name>\u{1f}<window title>"` (unit-separator) so the
    frontend treats it as an opaque token.
- Registered in `commands/mod.rs` and the `invoke_handler!` in `lib.rs`; frontend
  wrappers added in `services/clipboardService.js`.
- New tab shortcut setting `tab_shortcut_apps` plumbed through `settings.rs`
  (struct, defaults, migration map) and `commands/settings.rs` (`apply_field`).

### macOS window listing & focus (the important part)

The list and the focus action **must use the same title source**, otherwise the
string you click never matches the string in the list. This caused a long chain
of bugs (see below), and the final design uses the application's own **Window
menu** for both, via Accessibility (System Events):

- **List**: for each visible process, read its `Window` menu and take the window
  entries (the items after the last separator - macOS appends open windows
  there). Output is `"<process>\t<window title>"`.
- **Focus**: `click` the matching `Window` menu item (exact match first, then a
  substring fallback). The target window is selected **before** the app is
  activated, so the app comes forward already showing the right window (no flash
  of the previously-active window).

Why the Window menu and not other approaches:

- `CGWindowListCopyWindowInfo` (CoreGraphics) gives window titles fast and
  in-process, but window titles (`kCGWindowName`) require the **Screen Recording**
  permission, and its titles don't match the strings needed to focus a window.
- AX `AXRaise` / `AXMain` are **ignored by Chromium/Electron apps** (Google
  Chrome, VS Code) for real window focus - the wrong window stayed visible.
- The Window-menu click is the app's own command and is honored by every app
  tested (Chrome, VS Code, IntelliJ, Finder, native apps), so it is reliable and
  consistent with the list.

Net effect of the follow-up changes: removed the CoreGraphics path and the
`core-foundation` dependency; the feature now needs only **Accessibility**, not
Screen Recording.

### Frontend (React)

- New `src/components/AppsTab.jsx` (search input + clickable list).
- `App.jsx`: Apps state, cached loading, token-AND filtering, Enter / number-key
  selection, focus-then-hide handler, tab wiring.
- `hooks/useAppEvents.js`: Apps tab shortcut, number-key selection for Apps,
  refresh on window-shown.
- `components/Settings.jsx`: Apps hotkey field and renumbered defaults.

### Other platforms

**Windows** listing/focus is implemented via PowerShell (`Get-Process` /
`AppActivate` by PID). **Linux** is not implemented (returns an error).

## Code signing

The app is signed with a **stable self-signed identity** so macOS permission
grants survive rebuilds:

- A self-signed code-signing certificate named **`ClipX Dev`** lives in the
  login keychain.
- `src-tauri/tauri.conf.json` sets `bundle.macOS.signingIdentity = "ClipX Dev"`,
  so every `pnpm tauri build` signs the app with it.

Why this matters: before this, the app was **ad-hoc signed**, so every rebuild
produced a new code identity (cdhash) and macOS dropped all previously granted
permissions - forcing a re-grant after each build. With a stable certificate,
the TCC permission binds to the certificate, not the build, so the grant
**persists across rebuilds**.

Recreating the certificate on another machine (one time):

```sh
# 1. create a self-signed code-signing cert (config file avoids LibreSSL quirks)
cat > /tmp/clipxdev.cnf <<'CNF'
[req]
distinguished_name = dn
x509_extensions = v3
prompt = no
[dn]
CN = ClipX Dev
[v3]
basicConstraints = critical,CA:FALSE
keyUsage = critical,digitalSignature
extendedKeyUsage = critical,codeSigning
CNF
openssl req -x509 -newkey rsa:2048 -keyout /tmp/clipxdev.key -out /tmp/clipxdev.crt \
  -days 3650 -nodes -config /tmp/clipxdev.cnf

# 2. package + import (note: -legacy / -macalg sha1 so macOS can read the p12)
openssl pkcs12 -export -inkey /tmp/clipxdev.key -in /tmp/clipxdev.crt \
  -out /tmp/clipxdev.p12 -passout pass:clipxdev -name "ClipX Dev" -legacy -macalg sha1
security import /tmp/clipxdev.p12 -k ~/Library/Keychains/login.keychain-db \
  -P clipxdev -T /usr/bin/codesign -A
```

`security find-identity -v -p codesigning` will NOT list a self-signed cert (it is
untrusted), but `codesign --sign "ClipX Dev"` works anyway, which is all Tauri
needs.

## Permissions - cautions

macOS permissions (TCC) gate this feature. Required on macOS:

- **Accessibility** (System Settings > Privacy & Security > Accessibility):
  ClipX needs this to read other apps' Window menus and to click the menu item
  that focuses a window. **This is the one permission the feature depends on.**
- **Automation** ("ClipX wants to control System Events"): approve the prompt the
  first time. Granted automatically via the prompt; required for the AppleScript
  bridge.
- **Screen Recording is NOT needed** anymore (an earlier approach used it; it was
  removed).

Things to watch out for:

- **The app must be fully quit and relaunched after granting**, not just have its
  window closed. ClipX is an accessory app that **hides on window close** - the
  process keeps running, so a freshly granted permission only takes effect after
  an actual restart (quit from the tray, or `killall clipx-scaffold`).
- If listing shows only app names (no titles), or switching only activates the app
  without selecting the window, Accessibility is not effective - re-check the
  grant and restart.
- **Run the bundled `.app`, not the dev binary.** `pnpm tauri dev` runs a separate
  unsigned binary at a different path; permissions granted to the `.app` do not
  apply to it. Grant/test against `target/release/bundle/macos/ClipX.app` (or your
  installed `/Applications/ClipX.app`).
- **Self-signed = Gatekeeper is not satisfied.** A freshly copied build may need a
  one-time right-click > Open. Local build-and-run is unaffected. For real
  distribution you would need a Developer ID certificate and notarization.
- If you ever rotate or lose the `ClipX Dev` certificate, the identity changes and
  permissions must be granted once more.

