### PR TITLE
notification about new updates

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,52 @@
+# Releasing ClipX
+
+The update notification feature checks GitHub Releases to tell users a new
+version is available. Two failure modes cannot be caught by code, tests, or CI,
+so they are the responsibility of whoever cuts the release. Read the two
+warnings below before following the steps.
+
+## Release checklist
+
+Perform these steps in order:
+
+1. **Bump the version in `src-tauri/tauri.conf.json`.** Set `version` to the new
+   `X.Y.Z`.
+2. **Commit** the version bump.
+3. **Tag** the commit: `git tag vX.Y.Z` (the `v` prefix matches the workflow's
+   `v*` trigger; the tag version must match the `tauri.conf.json` version).
+4. **Push** the commit and the tag: `git push && git push --tags`. Pushing the
+   tag starts the release workflow, which builds every platform and creates a
+   **draft** release.
+5. **Publish the draft release.** Open the release on GitHub and click Publish.
+   The release stays a draft until you do this.
+
+## Warning: an unpublished draft release notifies nobody
+
+The client checks for updates with `GET /releases/latest`, and that endpoint
+**excludes drafts and prereleases**. A release left as a draft is invisible to
+every client:
+
+- No user is ever notified of the new version.
+- No error appears anywhere, not in the app, not in the logs, not in the API
+  response. The check simply reports the previous published release (or none).
+
+The release workflow always creates the release as a draft (`releaseDraft: true`
+in `.github/workflows/release.yml`). Step 5 is therefore mandatory: the release
+does not exist for clients until it is published.
+
+## Warning: `tauri.conf.json` is the only version that matters
+
+`src-tauri/tauri.conf.json` is the single source of truth that both the
+frontend `getVersion()` and the backend `app.package_info().version` read from,
+and the update check compares that value against the latest published release.
+
+- If you tag `vX.Y.Z` but forget to bump `tauri.conf.json`, the installed app
+  keeps reporting its old version. It will **notify forever** (thinking it is
+  out of date) or **never** (if the stale version already looks current),
+  depending on the values.
+- The versions in `package.json` and `src-tauri/Cargo.toml` do **not** affect
+  the update check. Keeping them in sync is tidy but not required for
+  notifications to work; `tauri.conf.json` is the one that must match the tag.
+
+Always bump `tauri.conf.json` (step 1) in the same release as the git tag
+(step 3), and make sure the two versions are identical.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -469,6 +469,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,7 +514,9 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "reqwest 0.12.28",
  "rusqlite",
+ "semver",
  "serde",
  "serde_json",
  "simplelog",
@@ -592,6 +611,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1322,8 +1350,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1345,10 +1375,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1661,6 +1694,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2120,6 +2169,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -3025,6 +3080,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.1",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,7 +3161,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -3062,6 +3173,17 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3103,6 +3225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,6 +3246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3197,6 +3334,44 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3230,6 +3405,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,6 +3431,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3266,10 +3461,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3461,6 +3697,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,7 +3778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3688,6 +3936,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,7 +4094,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4240,6 +4494,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4251,6 +4520,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4558,6 +4837,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4882,6 +5167,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4923,6 +5218,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5159,6 +5463,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5745,6 +6058,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,8 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 thiserror = "1"
 log = "0.4"
 simplelog = { version = "0.12", features = ["paris"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+semver = "1"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod logging;
 pub mod pinned;
 pub mod sessions;
 pub mod settings;
+pub mod updates;
 pub mod window_pin;
 
 use crate::error::AppError;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -33,6 +33,12 @@ fn apply_field(s: &mut Settings, key: &str, value: &str) -> Result<(), AppError>
         "tab_shortcut_sessions" => s.tab_shortcut_sessions = value.to_string(),
         "tab_shortcut_find" => s.tab_shortcut_find = value.to_string(),
         "theme" => s.theme = value.to_string(),
+        "check_updates_on_startup" => {
+            s.check_updates_on_startup = value.parse::<bool>().map_err(|_| {
+                AppError::Validation(format!("Invalid check_updates_on_startup: {value}"))
+            })?;
+        }
+        "dismissed_version" => s.dismissed_version = value.to_string(),
         _ => return Err(AppError::Settings(format!("Unknown setting: {key}"))),
     }
 
@@ -128,6 +134,25 @@ mod tests {
     fn apply_field_unknown_key() {
         let mut s = Settings::default();
         assert!(matches!(apply_field(&mut s, "bogus_key", "value"), Err(AppError::Settings(_))));
+    }
+
+    #[test]
+    fn apply_field_invalid_check_updates_on_startup() {
+        let mut s = Settings::default();
+        assert!(matches!(
+            apply_field(&mut s, "check_updates_on_startup", "maybe"),
+            Err(AppError::Validation(_))
+        ));
+        assert!(s.check_updates_on_startup);
+    }
+
+    #[test]
+    fn apply_field_valid_update_settings() {
+        let mut s = Settings::default();
+        apply_field(&mut s, "check_updates_on_startup", "false").unwrap();
+        assert!(!s.check_updates_on_startup);
+        apply_field(&mut s, "dismissed_version", "0.1.29").unwrap();
+        assert_eq!(s.dismissed_version, "0.1.29");
     }
 
     #[test]

--- a/src-tauri/src/commands/updates.rs
+++ b/src-tauri/src/commands/updates.rs
@@ -1,0 +1,162 @@
+use crate::error::AppError;
+use semver::Version;
+use std::time::Duration;
+use tauri::AppHandle;
+
+const RELEASES_URL: &str = "https://api.github.com/repos/adrianojlt/clipx/releases/latest";
+
+// GitHub rejects unauthenticated API requests without a User-Agent with 403.
+const USER_AGENT: &str = concat!("clipx/", env!("CARGO_PKG_VERSION"));
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(serde::Serialize)]
+pub struct UpdateInfo {
+    pub version: String,
+    pub notes: String,
+    pub url: String,
+}
+
+// Only the three fields the feature uses; serde ignores the rest of the payload.
+#[derive(serde::Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    html_url: String,
+    body: Option<String>,
+}
+
+#[tauri::command]
+pub async fn check_for_update(app: AppHandle) -> Result<Option<UpdateInfo>, AppError> {
+
+    let current = app.package_info().version.to_string();
+
+    let release: GithubRelease = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .user_agent(USER_AGENT)
+        .build()?
+        .get(RELEASES_URL)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    if !is_newer(&current, &release.tag_name) {
+        return Ok(None);
+    }
+
+    Ok(Some(UpdateInfo {
+        version: release.tag_name.strip_prefix('v').unwrap_or(&release.tag_name).to_string(),
+        notes: release.body.unwrap_or_default(),
+        url: release.html_url,
+    }))
+}
+
+/// Returns true when `latest_tag` names a release newer than `current`.
+///
+/// A leading `v` on the tag is tolerated. An unparseable version on either
+/// side is reported as "no update" rather than an error, so a malformed
+/// release tag can never block the app.
+fn is_newer(current: &str, latest_tag: &str) -> bool {
+
+    let latest = latest_tag.strip_prefix('v').unwrap_or(latest_tag);
+
+    let current = match Version::parse(current) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("could not parse current version {current}: {e}");
+            return false;
+        }
+    };
+
+    let latest = match Version::parse(latest) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("could not parse release tag {latest_tag}: {e}");
+            return false;
+        }
+    };
+
+    latest > current
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn newer_patch_with_v_prefix_is_an_update() {
+        assert!(is_newer("0.1.28", "v0.1.29"));
+    }
+
+    #[test]
+    fn numeric_compare_beats_lexical_compare() {
+        assert!(is_newer("0.1.9", "v0.1.10"));
+    }
+
+    #[test]
+    fn same_version_is_not_an_update() {
+        assert!(!is_newer("0.1.28", "0.1.28"));
+    }
+
+    #[test]
+    fn older_release_is_never_an_update() {
+        assert!(!is_newer("0.1.29", "v0.1.28"));
+    }
+
+    #[test]
+    fn unparseable_tag_is_not_an_update() {
+        assert!(!is_newer("0.1.28", "not-a-version"));
+    }
+
+    #[test]
+    fn prerelease_tag_does_not_panic() {
+        let _ = is_newer("0.1.28", "v0.2.0-beta.1");
+    }
+
+    // Trimmed capture of GET /repos/{owner}/{repo}/releases/latest, keeping a
+    // representative sample of the fields the struct does not declare.
+    const RELEASE_FIXTURE: &str = r###"{
+      "url": "https://api.github.com/repos/adrianojlt/clipx/releases/1234567",
+      "assets_url": "https://api.github.com/repos/adrianojlt/clipx/releases/1234567/assets",
+      "html_url": "https://github.com/adrianojlt/clipx/releases/tag/v0.1.29",
+      "id": 1234567,
+      "author": { "login": "adrianojlt", "id": 42, "type": "User" },
+      "tag_name": "v0.1.29",
+      "target_commitish": "main",
+      "name": "ClipX v0.1.29",
+      "draft": false,
+      "prerelease": false,
+      "created_at": "2026-07-20T10:11:12Z",
+      "published_at": "2026-07-20T10:30:00Z",
+      "assets": [
+        { "name": "ClipX_0.1.29_aarch64.dmg", "size": 4210000, "download_count": 7 }
+      ],
+      "tarball_url": "https://api.github.com/repos/adrianojlt/clipx/tarball/v0.1.29",
+      "body": "## Changes\n- add themes: light and dark\n- fix animation"
+    }"###;
+
+    #[test]
+    fn release_fixture_deserializes_and_ignores_unknown_fields() {
+        let release: GithubRelease = serde_json::from_str(RELEASE_FIXTURE).unwrap();
+
+        assert_eq!(release.tag_name, "v0.1.29");
+        assert_eq!(
+            release.html_url,
+            "https://github.com/adrianojlt/clipx/releases/tag/v0.1.29"
+        );
+        assert_eq!(
+            release.body.as_deref(),
+            Some("## Changes\n- add themes: light and dark\n- fix animation")
+        );
+    }
+
+    #[test]
+    fn release_without_body_deserializes() {
+        let release: GithubRelease =
+            serde_json::from_str(r#"{"tag_name":"v0.1.29","html_url":"https://x","body":null}"#)
+                .unwrap();
+
+        assert_eq!(release.body, None);
+    }
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub enum AppError {
     #[error("Database error: {0}")]
     Db(#[from] rusqlite::Error),
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
     #[error("JSON error: {0}")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -124,6 +124,7 @@ pub fn run() {
             commands::apps::focus_app,
             commands::window_pin::set_always_on_top,
             commands::window_pin::set_soft_pin,
+            commands::updates::check_for_update,
         ])
         .setup(|app| {
             #[cfg(target_os = "macos")]
@@ -279,11 +280,13 @@ fn build_tray(app: &tauri::App) -> Result<(), AppError> {
         .map_err(|e| AppError::Window(e.to_string()))?;
     let about_i = MenuItem::with_id(app, "about", "About", true, None::<&str>)
         .map_err(|e| AppError::Window(e.to_string()))?;
+    let check_i = MenuItem::with_id(app, "check_updates", "Check for Updates", true, None::<&str>)
+        .map_err(|e| AppError::Window(e.to_string()))?;
     let sep = tauri::menu::PredefinedMenuItem::separator(app)
         .map_err(|e| AppError::Window(e.to_string()))?;
     let quit_i = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)
         .map_err(|e| AppError::Window(e.to_string()))?;
-    let menu = Menu::with_items(app, &[&open_i, &settings_i, &about_i, &sep, &quit_i])
+    let menu = Menu::with_items(app, &[&open_i, &settings_i, &about_i, &check_i, &sep, &quit_i])
         .map_err(|e| AppError::Window(e.to_string()))?;
 
     TrayIconBuilder::new()
@@ -294,6 +297,10 @@ fn build_tray(app: &tauri::App) -> Result<(), AppError> {
             "open" => show_window(app, "main"),
             "settings" => show_window(app, "settings"),
             "about" => show_window(app, "about"),
+            "check_updates" => {
+                show_window(app, "settings");
+                let _ = app.emit("check-updates-requested", ());
+            }
             "quit" => app.exit(0),
             _ => {}
         })

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -18,10 +18,18 @@ pub struct Settings {
     pub open_apps_hotkey: String,
     #[serde(default = "default_theme")]
     pub theme: String,
+    #[serde(default = "default_true")]
+    pub check_updates_on_startup: bool,
+    #[serde(default)]
+    pub dismissed_version: String,
 }
 
 fn default_theme() -> String {
     "dark".to_string()
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl Default for Settings {
@@ -38,6 +46,8 @@ impl Default for Settings {
             tab_shortcut_find: format!("{tab_mod}+F"),
             open_apps_hotkey: "Control+Option+Esc".to_string(),
             theme: default_theme(),
+            check_updates_on_startup: true,
+            dismissed_version: String::new(),
         }
     }
 }
@@ -374,6 +384,43 @@ mod tests {
     }
 
     #[test]
+    fn read_settings_file_defaults_keys_added_after_the_file_was_written() {
+
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("settings.json");
+
+        // A typed settings.json as written before check_updates_on_startup and
+        // dismissed_version existed. Guards the #[serde(default)] on both: without
+        // it, an existing user's file fails to parse and is silently replaced by
+        // defaults, losing every setting they had.
+        fs::write(
+            &path,
+            r#"{"hotkey":"Option+Space","history_limit":20,"window_width":600.0,"window_height":700.0,"tab_shortcut_pinned":"Command+1","tab_shortcut_history":"Command+2","tab_shortcut_sessions":"Command+3","tab_shortcut_find":"Command+F","open_apps_hotkey":"Control+Option+Esc","theme":"light"}"#,
+        )
+        .unwrap();
+
+        let loaded = read_settings_file(&path);
+
+        // New keys take their defaults.
+        assert!(loaded.check_updates_on_startup);
+        assert_eq!(loaded.dismissed_version, "");
+
+        // Pre-existing values survive, i.e. the file parsed rather than being discarded.
+        assert_eq!(loaded.theme, "light");
+        assert_eq!(loaded.hotkey, "Option+Space");
+
+        // No corrupt backup: the typed branch handled it.
+        let backups = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains("corrupt"))
+            .count();
+        assert_eq!(backups, 0);
+    }
+
+    #[test]
     fn validate_clamps_all_fields() {
 
         let mut s = Settings {
@@ -387,6 +434,8 @@ mod tests {
             tab_shortcut_find: "C".to_string(),
             open_apps_hotkey: "F".to_string(),
             theme: "dark".to_string(),
+            check_updates_on_startup: true,
+            dismissed_version: String::new(),
         };
 
         s.validate();

--- a/src/App.css
+++ b/src/App.css
@@ -105,6 +105,56 @@
   opacity: 1;
 }
 
+/* Anchored to the right edge, mirroring .pin-btn on the left. Positioned out of
+   the flex flow on purpose: the icon and <h1> stay exactly centred whether or
+   not the badge is showing, and the pin label needs no suppression. */
+.update-badge {
+  position: absolute;
+  right: 0.6rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.1rem 0.2rem 0.1rem 0.4rem;
+  border: 1px solid var(--app-accent);
+  border-radius: 999px;
+  font-size: 0.7rem;
+  line-height: 1.6;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.update-badge-version {
+  color: var(--app-accent);
+  font-weight: 500;
+}
+
+.update-badge-action {
+  background: var(--app-accent);
+  color: var(--app-bg);
+  border: none;
+  border-radius: 999px;
+  padding: 0 0.45rem;
+  font-size: 0.7rem;
+  line-height: 1.5;
+  cursor: pointer;
+}
+
+.update-badge-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--app-text-muted);
+  font-size: 0.85rem;
+  line-height: 1;
+  padding: 0 0.15rem;
+  cursor: pointer;
+}
+
+.update-badge-dismiss:hover {
+  color: var(--app-text-strong);
+}
+
 .tabs {
   display: flex;
   background: var(--app-surface);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import {
   getSessions,
   getClipboard,
   getSetting,
+  setSetting,
   activateSession,
   listOpenApps,
   focusApp,
@@ -15,6 +16,8 @@ import {
   setAlwaysOnTop,
   setSoftPin,
 } from "./services/clipboardService";
+import { checkForUpdate } from "./services/updateService";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 import { useAppEvents } from "./hooks/useAppEvents";
 import { IS_MAC } from "./utils/shortcuts";
@@ -42,6 +45,7 @@ function App() {
   // pinMode: 'none' | 'always-on-top' | 'soft'. Ephemeral, resets on restart.
   const [pinMode, setPinMode] = useState("none");
   const [showPinLabel, setShowPinLabel] = useState(false);
+  const [update, setUpdate] = useState(null);
   const pinLabelTimer = useRef(null);
   const pinChangeAtRef = useRef(0);
   const [history, setHistory] = useState([]);
@@ -197,6 +201,43 @@ function App() {
     if (pinLabelTimer.current) clearTimeout(pinLabelTimer.current);
   }, []);
 
+  // Startup update check. Runs once, off the first-paint path, and stays silent
+  // in the UI whatever happens: a clipboard manager must not interrupt the user
+  // because a version lookup failed.
+  useEffect(() => {
+
+    const check = async () => {
+
+      try {
+        if ((await getSetting("check_updates_on_startup")) !== "true") return;
+
+        const info = await checkForUpdate();
+
+        if (!info) return;
+        if (info.version === (await getSetting("dismissed_version"))) return;
+
+        setUpdate(info);
+      } catch (e) {
+        await logError("warn", `Startup update check failed: ${e}`);
+      }
+    };
+
+    check();
+  }, []);
+
+  const dismissUpdate = useCallback(async () => {
+
+    const version = update?.version;
+
+    setUpdate(null);
+
+    try {
+      if (version) await setSetting("dismissed_version", version);
+    } catch (e) {
+      await logError("warn", `Failed to persist dismissed version: ${e}`);
+    }
+  }, [update]);
+
   useEffect(() => {
     loadApps();
   }, [loadApps]);
@@ -316,6 +357,27 @@ function App() {
         </span>
         <img src="/icon.png" alt="ClipX" className="app-icon" />
         <h1>ClipX</h1>
+        {update && (
+          <span className="update-badge" onMouseDown={(e) => e.stopPropagation()}>
+            <span className="update-badge-version">v{update.version}</span>
+            <button
+              type="button"
+              className="update-badge-action"
+              onClick={async () => await openUrl(update.url)}
+            >
+              Download
+            </button>
+            <button
+              type="button"
+              className="update-badge-dismiss"
+              title="Dismiss"
+              aria-label="Dismiss update notification"
+              onClick={dismissUpdate}
+            >
+              ×
+            </button>
+          </span>
+        )}
       </div>
       {mode === "apps" && (
         <AppsTab

--- a/src/components/Settings.css
+++ b/src/components/Settings.css
@@ -420,3 +420,16 @@ body {
   padding: 8px 20px 0;
   flex-shrink: 0;
 }
+
+/* ── UPDATES ─────────────────────────────────────────── */
+.update-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.update-status {
+  margin: 8px 0 0;
+  font-size: 11.5px;
+  color: var(--text-3);
+}
+.update-status.is-error { color: var(--danger); }

--- a/src/components/Settings.css
+++ b/src/components/Settings.css
@@ -433,3 +433,15 @@ body {
   color: var(--text-3);
 }
 .update-status.is-error { color: var(--danger); }
+.update-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+.update-toggle input {
+  accent-color: var(--accent);
+  cursor: pointer;
+}

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -465,6 +465,14 @@ function OthersPanel({ s, set, checkRequested, onCheckConsumed }) {
           <p className="update-status is-error">Could not check for updates. Try again later.</p>
         )}
       </div>
+      <label className="update-toggle">
+        <input
+          type="checkbox"
+          checked={s.checkUpdatesOnStartup}
+          onChange={(e) => set("checkUpdatesOnStartup", e.target.checked)}
+        />
+        <span>Check for updates on startup</span>
+      </label>
     </>
   );
 }
@@ -487,6 +495,7 @@ function Settings() {
     windowWidth: 600,
     windowHeight: 700,
     theme: "dark",
+    checkUpdatesOnStartup: true,
   });
 
   const set = (k, v) => {
@@ -542,7 +551,7 @@ function Settings() {
           return fallback;
         }
       };
-      const [hotkey, openApps, pinned, history, sessions, find, limit, width, height, theme] = await Promise.all([
+      const [hotkey, openApps, pinned, history, sessions, find, limit, width, height, theme, checkUpdates] = await Promise.all([
         safeGet("hotkey", "Option+Space"),
         safeGet("open_apps_hotkey", "Control+Option+Esc"),
         safeGet("tab_shortcut_pinned", `${TAB_MOD}+1`),
@@ -553,8 +562,9 @@ function Settings() {
         safeGet("window_width", 600, (v) => Number(v) || 600),
         safeGet("window_height", 700, (v) => Number(v) || 700),
         safeGet("theme", "dark"),
+        safeGet("check_updates_on_startup", true, (v) => v === "true"),
       ]);
-      setS({ hotkey, openAppsHotkey: openApps, tabShortcutPinned: pinned, tabShortcutHistory: history, tabShortcutSessions: sessions, tabShortcutFind: find, historyLimit: limit, windowWidth: width, windowHeight: height, theme });
+      setS({ hotkey, openAppsHotkey: openApps, tabShortcutPinned: pinned, tabShortcutHistory: history, tabShortcutSessions: sessions, tabShortcutFind: find, historyLimit: limit, windowWidth: width, windowHeight: height, theme, checkUpdatesOnStartup: checkUpdates });
     };
     load();
   }, []);
@@ -578,6 +588,7 @@ function Settings() {
     await attempt(() => setSetting("window_width", String(s.windowWidth)));
     await attempt(() => setSetting("window_height", String(s.windowHeight)));
     await attempt(() => setSetting("theme", s.theme));
+    await attempt(() => setSetting("check_updates_on_startup", String(s.checkUpdatesOnStartup)));
 
     await attempt(() => applyWindowSize());
     await attempt(() => applyTheme());

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,5 +1,8 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { listen } from "@tauri-apps/api/event";
+import { getVersion } from "@tauri-apps/api/app";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   getSetting,
   setSetting,
@@ -8,6 +11,7 @@ import {
   applyWindowSize,
   logError,
 } from "../services/clipboardService";
+import { checkForUpdate } from "../services/updateService";
 import { IS_MAC } from "../utils/shortcuts";
 import { resolveTheme, applyTheme } from "../theme";
 import "./Settings.css";
@@ -368,7 +372,50 @@ function UIPanel({ s, set }) {
   );
 }
 
-function OthersPanel({ s, set }) {
+function OthersPanel({ s, set, checkRequested, onCheckConsumed }) {
+
+  // Local only. The check is an immediate action and must never mark the form dirty.
+  const [version, setVersion] = useState("");
+  const [status, setStatus] = useState("idle");
+  const [update, setUpdate] = useState(null);
+
+  // A ref, not `status`, so the tray path sees an in-flight check even when it
+  // fires from a closure that captured an older render.
+  const checkingRef = useRef(false);
+
+  useEffect(() => {
+    const load = async () => setVersion(await getVersion());
+    load();
+  }, []);
+
+  const runCheck = useCallback(async () => {
+
+    if (checkingRef.current) return;
+
+    checkingRef.current = true;
+    setStatus("checking");
+
+    try {
+      const info = await checkForUpdate();
+      setUpdate(info);
+      setStatus(info ? "available" : "current");
+    } catch (e) {
+      setUpdate(null);
+      setStatus("error");
+      await logError("error", `Update check failed: ${e}`);
+    } finally {
+      checkingRef.current = false;
+    }
+  }, []);
+
+  // One-shot: the flag is cleared as it is consumed, so returning to this tab
+  // later does not replay the tray's request.
+  useEffect(() => {
+    if (!checkRequested) return;
+    onCheckConsumed();
+    runCheck();
+  }, [checkRequested, onCheckConsumed, runCheck]);
+
   return (
     <>
       <div className="section-header">
@@ -389,6 +436,35 @@ function OthersPanel({ s, set }) {
         </div>
         <div className="meter-labels"><span>1</span><span>50</span></div>
       </div>
+      <div className="section-header">
+        <h3>Updates</h3>
+        <p>Check GitHub for a newer release.</p>
+      </div>
+      <div className="field">
+        <div className="field-label">Current version{version && ` v${version}`}</div>
+        <div className="update-actions">
+          <button
+            className="btn btn-ghost"
+            type="button"
+            onClick={runCheck}
+            disabled={status === "checking"}
+          >
+            {status === "checking" ? "Checking…" : "Check for updates"}
+          </button>
+          {status === "available" && update && (
+            <button className="btn btn-primary" type="button" onClick={async () => await openUrl(update.url)}>
+              Download
+            </button>
+          )}
+        </div>
+        {status === "current" && <p className="update-status">ClipX is up to date.</p>}
+        {status === "available" && update && (
+          <p className="update-status">Version {update.version} is available.</p>
+        )}
+        {status === "error" && (
+          <p className="update-status is-error">Could not check for updates. Try again later.</p>
+        )}
+      </div>
     </>
   );
 }
@@ -398,6 +474,7 @@ function Settings() {
   const [dirty, setDirty] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState("");
+  const [checkRequested, setCheckRequested] = useState(false);
 
   const [s, setS] = useState({
     hotkey: "",
@@ -417,6 +494,35 @@ function Settings() {
     setDirty(true);
     setSaved(false);
   };
+
+  // Attached on mount so a tray click is never lost. The settings window is
+  // created hidden at startup, so this runs long before the menu can be used.
+  useEffect(() => {
+
+    let cancelled = false;
+    let unlisten;
+
+    const attach = async () => {
+
+      const fn = await listen("check-updates-requested", () => {
+        setActiveTab("others");
+        setCheckRequested(true);
+      });
+
+      if (cancelled) { fn(); return; }
+
+      unlisten = fn;
+    };
+
+    attach();
+
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  const onCheckConsumed = useCallback(() => setCheckRequested(false), []);
 
   useEffect(() => {
     const onKey = async (e) => {
@@ -495,7 +601,14 @@ function Settings() {
         <div className="content-scroll" key={activeTab}>
           {activeTab === "hotkeys" && <HotkeysPanel s={s} set={set} />}
           {activeTab === "ui" && <UIPanel s={s} set={set} />}
-          {activeTab === "others" && <OthersPanel s={s} set={set} />}
+          {activeTab === "others" && (
+            <OthersPanel
+              s={s}
+              set={set}
+              checkRequested={checkRequested}
+              onCheckConsumed={onCheckConsumed}
+            />
+          )}
         </div>
       </div>
       {error && <p className="error">{error}</p>}

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -533,41 +533,54 @@ function Settings() {
 
   const onCheckConsumed = useCallback(() => setCheckRequested(false), []);
 
-  useEffect(() => {
-    const onKey = async (e) => {
-      if (e.key === "Escape") await getCurrentWindow().hide();
+  // Reloads the buffered form from disk. Called on mount and again whenever the
+  // user abandons an edit, since the window is only hidden and never unmounts.
+  const load = useCallback(async () => {
+    const safeGet = async (key, fallback, transform = (v) => v) => {
+      try {
+        return transform(await getSetting(key));
+      } catch (e) {
+        await logError("warn", `Failed to load setting ${key}: ${e}`);
+        return fallback;
+      }
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    const [hotkey, openApps, pinned, history, sessions, find, limit, width, height, theme, checkUpdates] = await Promise.all([
+      safeGet("hotkey", "Option+Space"),
+      safeGet("open_apps_hotkey", "Control+Option+Esc"),
+      safeGet("tab_shortcut_pinned", `${TAB_MOD}+1`),
+      safeGet("tab_shortcut_history", `${TAB_MOD}+2`),
+      safeGet("tab_shortcut_sessions", `${TAB_MOD}+3`),
+      safeGet("tab_shortcut_find", `${TAB_MOD}+F`),
+      safeGet("history_limit", 20, Number),
+      safeGet("window_width", 600, (v) => Number(v) || 600),
+      safeGet("window_height", 700, (v) => Number(v) || 700),
+      safeGet("theme", "dark"),
+      safeGet("check_updates_on_startup", true, (v) => v === "true"),
+    ]);
+    setS({ hotkey, openAppsHotkey: openApps, tabShortcutPinned: pinned, tabShortcutHistory: history, tabShortcutSessions: sessions, tabShortcutFind: find, historyLimit: limit, windowWidth: width, windowHeight: height, theme, checkUpdatesOnStartup: checkUpdates });
   }, []);
 
   useEffect(() => {
-    const load = async () => {
-      const safeGet = async (key, fallback, transform = (v) => v) => {
-        try {
-          return transform(await getSetting(key));
-        } catch (e) {
-          await logError("warn", `Failed to load setting ${key}: ${e}`);
-          return fallback;
-        }
-      };
-      const [hotkey, openApps, pinned, history, sessions, find, limit, width, height, theme, checkUpdates] = await Promise.all([
-        safeGet("hotkey", "Option+Space"),
-        safeGet("open_apps_hotkey", "Control+Option+Esc"),
-        safeGet("tab_shortcut_pinned", `${TAB_MOD}+1`),
-        safeGet("tab_shortcut_history", `${TAB_MOD}+2`),
-        safeGet("tab_shortcut_sessions", `${TAB_MOD}+3`),
-        safeGet("tab_shortcut_find", `${TAB_MOD}+F`),
-        safeGet("history_limit", 20, Number),
-        safeGet("window_width", 600, (v) => Number(v) || 600),
-        safeGet("window_height", 700, (v) => Number(v) || 700),
-        safeGet("theme", "dark"),
-        safeGet("check_updates_on_startup", true, (v) => v === "true"),
-      ]);
-      setS({ hotkey, openAppsHotkey: openApps, tabShortcutPinned: pinned, tabShortcutHistory: history, tabShortcutSessions: sessions, tabShortcutFind: find, historyLimit: limit, windowWidth: width, windowHeight: height, theme, checkUpdatesOnStartup: checkUpdates });
-    };
     load();
-  }, []);
+  }, [load]);
+
+  // Cancel and Escape abandon the buffered edits. The window is hidden first so
+  // the reset is not visible as fields flicking back to their old values.
+  const discardAndHide = useCallback(async () => {
+    await getCurrentWindow().hide();
+    setError("");
+    setSaved(false);
+    setDirty(false);
+    await load();
+  }, [load]);
+
+  useEffect(() => {
+    const onKey = async (e) => {
+      if (e.key === "Escape") await discardAndHide();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [discardAndHide]);
 
   const handleSave = async () => {
 
@@ -635,7 +648,7 @@ function Settings() {
           {!dirty && !saved && <span className="status status-idle">All changes saved</span>}
         </div>
         <div className="footer-actions">
-          <button className="btn btn-ghost" type="button" onClick={async () => await getCurrentWindow().hide()}>Cancel</button>
+          <button className="btn btn-ghost" type="button" onClick={discardAndHide}>Cancel</button>
           <button
             className={`btn btn-primary${dirty ? "" : " is-disabled"}`}
             type="button"

--- a/src/services/updateService.js
+++ b/src/services/updateService.js
@@ -1,0 +1,3 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export const checkForUpdate = () => invoke("check_for_update");


### PR DESCRIPTION
Add update notification against GitHub Releases

Adds an in-app update check so users learn when a newer ClipX version is published, without any auto-download or telemetry. All version comparison is local; the only network call is a single read of the public GitHub Releases API.

What it does

- Manual check in Settings > Others via a "Check for updates" button. Reports the available version and release notes, with a "Download" action that opens the release page in the default browser.
- Tray entry: adds "Check for Updates" to the tray menu (order: Open, Settings, About, Check for Updates, separator, Quit). Selecting it opens Settings on the Others tab and runs the check.
- Startup check + title-bar badge: on launch the app checks once and, if an update exists, shows a badge in the popup title bar. Clicking the badge opens the release download page.
- Settings toggle to enable/disable the automatic startup check. Persisted in settings.

How the check works

- Calls GET /repos/adrianojlt/clipx/releases/latest. That endpoint excludes drafts and prereleases, so only published releases ever notify.
- Compares the installed version (app.package_info().version, sourced from tauri.conf.json) against the release tag using semver, not lexical comparison, so 0.1.10 > 0.1.9.
- A leading v on the tag is tolerated. An unparseable version on either side is treated as "no update" and logged, never surfaced as an error, so a malformed tag can never block the app.
- Sends a User-Agent (GitHub returns 403 without one) and a 10s timeout.

Backend

- New command check_for_update in src-tauri/src/commandtion<UpdateInfo> (Result<_, AppError> per projectconvention). Registered in mod.rs and the invoke_handler!.
- Settings command additions for the startup-check toggds/settings.rs and settings.rs.
- New AppError variant(s) for the HTTP/JSON path.

Frontend

- src/services/updateService.js wrapper for the command.
- Badge + startup check wiring in App.jsx / App.css.
- Settings UI (button, result display, toggle) in Settings.jsx / Settings.css.

Docs

- RELEASING.md release checklist covering the ordered steps (bump tauri.conf.json, commit, tag, push, publish the draft release), with two warnings: an unpublished draft notifies nobody and ri.conf.json is the only version the check reads.

Testing

- cargo test: 47 passed (includes is_newer semver casesparseable tag, and a GitHub payload fixture that ignores unknown fields).
- pnpm test: 11 passed. pnpm lint: clean.
- Manual verification on macOS: manual check, tray entry, and startup badge all pass; badge redirects to the v0.1.29 download page.
Windows and Linux sign-off tracked separately (no hardw

Notes

- release.yml intentionally unchanged; it already creatDraft: true).
- package.json and Cargo.toml versions do not affect the check.